### PR TITLE
Fixes to the add and remove mentor flows

### DIFF
--- a/app/controllers/mentors.js
+++ b/app/controllers/mentors.js
@@ -53,12 +53,15 @@ exports.mentor_details = (req, res) => {
 /// ------------------------------------------------------------------------ ///
 
 exports.new_mentor_get = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+
   let back = `/organisations/${req.params.organisationId}/mentors`
   if (req.query.referrer === 'check') {
     back = `/organisations/${req.params.organisationId}/mentors/new/check`
   }
 
   res.render('../views/mentors/find', {
+    organisation,
     mentor: req.session.data.mentor,
     actions: {
       save: `/organisations/${req.params.organisationId}/mentors/new`,
@@ -69,7 +72,14 @@ exports.new_mentor_get = (req, res) => {
 }
 
 exports.new_mentor_post = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+
   const errors = []
+
+  const mentor = mentorModel.findOne({
+    organisationId: req.params.organisationId,
+    trn: req.session.data.mentor.trn
+  })
 
   if (!req.session.data.mentor.trn.length) {
     const error = {}
@@ -83,14 +93,7 @@ exports.new_mentor_post = (req, res) => {
     error.href = '#mentor'
     error.text = 'Enter a valid teacher reference number (TRN)'
     errors.push(error)
-  }
-
-  const mentor = mentorModel.findOne({
-    organisationId: req.params.organisationId,
-    trn: req.session.data.mentor.trn
-  })
-
-  if (mentor) {
+  } else if (mentor) {
     const error = {}
     error.fieldName = 'mentor'
     error.href = '#mentor'
@@ -100,6 +103,7 @@ exports.new_mentor_post = (req, res) => {
 
   if (errors.length) {
     res.render('../views/mentors/find', {
+      organisation,
       mentor: req.session.data.mentor,
       actions: {
         save: `/organisations/${req.params.organisationId}/mentors/new`,

--- a/app/controllers/organisations.js
+++ b/app/controllers/organisations.js
@@ -27,7 +27,11 @@ exports.organisation = (req, res) => {
   // put the selected organisation into the passport object
   // for use around the service
   req.session.passport.organisation = organisation
-  res.redirect(`/organisations/${req.params.organisationId}/mentors`)
+  if (organisation.type === 'school') {
+    res.redirect(`/organisations/${req.params.organisationId}/mentors`)
+  } else {
+    res.redirect(`/organisations/${req.params.organisationId}/details`)
+  }
 }
 
 /// ------------------------------------------------------------------------ ///

--- a/app/controllers/support/organisation-mentors.js
+++ b/app/controllers/support/organisation-mentors.js
@@ -47,12 +47,15 @@ exports.mentor_details = (req, res) => {
 /// ------------------------------------------------------------------------ ///
 
 exports.new_mentor_get = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+
   let back = `/support/organisations/${req.params.organisationId}/mentors`
   if (req.query.referrer === 'check') {
     back = `/support/organisations/${req.params.organisationId}/mentors/new/check`
   }
 
   res.render('../views/support/organisations/mentors/find', {
+    organisation,
     mentor: req.session.data.mentor,
     actions: {
       save: `/support/organisations/${req.params.organisationId}/mentors/new`,
@@ -63,7 +66,14 @@ exports.new_mentor_get = (req, res) => {
 }
 
 exports.new_mentor_post = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+
   const errors = []
+
+  const mentor = mentorModel.findOne({
+    organisationId: req.params.organisationId,
+    trn: req.session.data.mentor.trn
+  })
 
   if (!req.session.data.mentor.trn.length) {
     const error = {}
@@ -77,14 +87,7 @@ exports.new_mentor_post = (req, res) => {
     error.href = '#mentor'
     error.text = 'Enter a valid teacher reference number (TRN)'
     errors.push(error)
-  }
-
-  const mentor = mentorModel.findOne({
-    organisationId: req.params.organisationId,
-    trn: req.session.data.mentor.trn
-  })
-
-  if (mentor) {
+  } else if (mentor) {
     const error = {}
     error.fieldName = 'mentor'
     error.href = '#mentor'
@@ -94,6 +97,7 @@ exports.new_mentor_post = (req, res) => {
 
   if (errors.length) {
     res.render('../views/support/organisations/mentors/find', {
+      organisation,
       mentor: req.session.data.mentor,
       actions: {
         save: `/support/organisations/${req.params.organisationId}/mentors/new`,

--- a/app/views/mentors/check-your-answers.njk
+++ b/app/views/mentors/check-your-answers.njk
@@ -8,11 +8,7 @@
   {% set title = "No results found for ‘" + data.mentor.trn + "’" %}
 {% endif %}
 
-{% if referrer == "change" or currentMentor %}
-  {% set caption = currentMentor.firstName + " " + currentMentor.lastName %}
-{% else %}
-  {% set caption = "Add mentor" %}
-{% endif %}
+{% set caption = "Add mentor" %}
 
 {% block pageTitle %}
   {{ "Error: " if errors.length }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
@@ -40,7 +36,7 @@
           {% include "_includes/mentors/check-your-answers.njk" %}
 
           {{ govukButton({
-            text: "Update mentor" if referrer == "change" else "Add mentor"
+            text: "Add mentor"
           }) }}
 
         </form>
@@ -49,6 +45,11 @@
           <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
         </p>
       {% else %}
+
+        <p class="govuk-body">
+          Check that you typed in the teacher reference number (TRN) correctly.
+        </p>
+
         <p class="govuk-body">
           <a class="govuk-link" href="{{ actions.change }}">Change your search</a>
         </p>

--- a/app/views/mentors/find.njk
+++ b/app/views/mentors/find.njk
@@ -14,7 +14,7 @@
 
 {% block content %}
 
-  {% include "_includes/notification-banner.njk" %}
+  {% include "_includes/error-summary.njk" %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/support/organisations/mentors/check-your-answers.njk
+++ b/app/views/support/organisations/mentors/check-your-answers.njk
@@ -9,11 +9,7 @@
   {% set title = "No results found for ‘" + data.mentor.trn + "’" %}
 {% endif %}
 
-{% if referrer == "change" or currentMentor %}
-  {% set caption = currentMentor.firstName + " " + currentMentor.lastName %}
-{% else %}
-  {% set caption = "Add mentor" %}
-{% endif %}
+{% set caption = "Add mentor - " + organisation.name %}
 
 {% block pageTitle %}
   {{ "Error: " if errors.length }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
@@ -41,7 +37,7 @@
           {% include "_includes/mentors/check-your-answers.njk" %}
 
           {{ govukButton({
-            text: "Update mentor" if referrer == "change" else "Add mentor"
+            text: "Add mentor"
           }) }}
 
         </form>
@@ -50,6 +46,10 @@
           <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
         </p>
       {% else %}
+        <p class="govuk-body">
+          Check that you typed in the teacher reference number (TRN) correctly.
+        </p>
+
         <p class="govuk-body">
           <a class="govuk-link" href="{{ actions.change }}">Change your search</a>
         </p>

--- a/app/views/support/organisations/mentors/delete.njk
+++ b/app/views/support/organisations/mentors/delete.njk
@@ -4,7 +4,7 @@
 {% set secondaryNavId = "mentors" %}
 
 {% set title = "Are you sure you want to remove this mentor?" %}
-{% set caption = mentor.firstName + " " + mentor.lastName %}
+{% set caption = mentor.firstName + " " + mentor.lastName + " - " + organisation.name %}
 
 {% block pageTitle %}
   {{ "Error: " if errors.length }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK

--- a/app/views/support/organisations/mentors/find.njk
+++ b/app/views/support/organisations/mentors/find.njk
@@ -4,7 +4,7 @@
 {% set secondaryNavId = "mentors" %}
 
 {% set title = "Enter a teacher reference number (TRN)" %}
-{% set caption = "Add mentor" %}
+{% set caption = "Add mentor - " + organisation.name %}
 
 {% block beforeContent %}
 {{ govukBackLink({
@@ -15,7 +15,7 @@
 
 {% block content %}
 
-  {% include "_includes/notification-banner.njk" %}
+  {% include "_includes/error-summary.njk" %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/support/organisations/mentors/show.njk
+++ b/app/views/support/organisations/mentors/show.njk
@@ -3,7 +3,7 @@
 {% set primaryNavId = "organisations" %}
 
 {% set title = mentor.firstName + " " + mentor.lastName %}
-{% set caption = organisation.name %}
+{% set caption = "Mentors - " + organisation.name %}
 
 {% block beforeContent %}
 {{ govukBackLink({
@@ -24,7 +24,7 @@
       {% include "_includes/mentors/details.njk" %}
 
       <p class="govuk-body">
-        <a class="govuk-link app-link--destructive" href="{{ actions.delete }}">Remove user</a>
+        <a class="govuk-link app-link--destructive" href="{{ actions.delete }}">Remove mentor</a>
       </p>
 
     </div>

--- a/app/views/support/organisations/users/edit.njk
+++ b/app/views/support/organisations/users/edit.njk
@@ -40,44 +40,44 @@
           }
         }) %}
 
-        {{ govukInput({
-          id: "firstName",
-          name: "user[firstName]",
-          label: {
-            text: "First name",
-            classes: "govuk-label--s"
-          },
-          errorMessage: errors | getErrorMessage("firstName"),
-          value: user.firstName,
-          classes: "govuk-!-width-two-thirds"
-        }) }}
+          {{ govukInput({
+            id: "firstName",
+            name: "user[firstName]",
+            label: {
+              text: "First name",
+              classes: "govuk-label--s"
+            },
+            errorMessage: errors | getErrorMessage("firstName"),
+            value: user.firstName,
+            classes: "govuk-!-width-two-thirds"
+          }) }}
 
-        {{ govukInput({
-          id: "lastName",
-          name: "user[lastName]",
-          label: {
-            text: "Last name",
-            classes: "govuk-label--s"
-          },
-          errorMessage: errors | getErrorMessage("lastName"),
-          value: user.lastName,
-          classes: "govuk-!-width-two-thirds"
-        }) }}
+          {{ govukInput({
+            id: "lastName",
+            name: "user[lastName]",
+            label: {
+              text: "Last name",
+              classes: "govuk-label--s"
+            },
+            errorMessage: errors | getErrorMessage("lastName"),
+            value: user.lastName,
+            classes: "govuk-!-width-two-thirds"
+          }) }}
 
-        {{ govukInput({
-          id: "email",
-          name: "user[email]",
-          label: {
-            text: "Email address",
-            classes: "govuk-label--s"
-          },
-          errorMessage: errors | getErrorMessage("email"),
-          value: user.email
-        }) }}
+          {{ govukInput({
+            id: "email",
+            name: "user[email]",
+            label: {
+              text: "Email address",
+              classes: "govuk-label--s"
+            },
+            errorMessage: errors | getErrorMessage("email"),
+            value: user.email
+          }) }}
 
-        {{ govukButton({
-          text: "Continue"
-        }) }}
+          {{ govukButton({
+            text: "Continue"
+          }) }}
 
         {% endcall %}
 

--- a/app/views/support/organisations/users/show.njk
+++ b/app/views/support/organisations/users/show.njk
@@ -3,7 +3,7 @@
 {% set primaryNavId = "organisations" %}
 
 {% set title = user.firstName + " " + user.lastName %}
-{% set caption = organisation.name %}
+{% set caption = "Users - " + organisation.name %}
 
 {% block beforeContent %}
 {{ govukBackLink({


### PR DESCRIPTION
We identified several errors in the 'Add mentor' work on Manage school placements, which also occur in Claim funding for mentors. This PR contains those fixes. For example:

- Fix the 'Remove mentor' link label - it previously said 'Remove user'
- Add error summary to 'Enter a teacher reference number (TRN)' view
- Fix error checking order - Enter a TRN, enter a valid TRN, mentor already exists
- Add organisation name to views

Related Manage school placements PR: https://github.com/DFE-Digital/school-placements-beta-prototype/pull/49