### PR TITLE
Fixes to the claims service

### DIFF
--- a/app/controllers/claims.js
+++ b/app/controllers/claims.js
@@ -1,4 +1,5 @@
 const claimModel = require('../models/claims')
+const mentorModel = require('../models/mentors')
 const organisationModel = require('../models/organisations')
 const claimHelper = require('../helpers/claims')
 const mentorHelper = require('../helpers/mentors')
@@ -10,6 +11,7 @@ const mentorHelper = require('../helpers/mentors')
 exports.claim_list = (req, res) => {
   const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
   const claims = claimModel.findMany({ organisationId: req.params.organisationId })
+  const mentors = mentorModel.findMany({ organisationId: req.params.organisationId })
 
   delete req.session.data.claim
   delete req.session.data.mentor
@@ -19,9 +21,11 @@ exports.claim_list = (req, res) => {
   res.render('../views/claims/list', {
     organisation,
     claims,
+    mentors,
     actions: {
       new: `/organisations/${req.params.organisationId}/claims/new`,
-      view: `/organisations/${req.params.organisationId}/claims`
+      view: `/organisations/${req.params.organisationId}/claims`,
+      mentors: `/organisations/${req.params.organisationId}/mentors`
     }
   })
 }

--- a/app/views/claims/list.njk
+++ b/app/views/claims/list.njk
@@ -17,10 +17,26 @@
 
       {% include "_includes/page-heading.njk" %}
 
-      {{ govukButton({
-        text: "Add claim",
-        href: actions.new
-      }) }}
+      {% if not mentors.length %}
+        {% set mentorHtml %}
+          <p class="govuk-body">
+            You need to <a href="{{ actions.mentors }}" class="govuk-link">add a mentor</a> before creating a claim.
+          </p>
+        {% endset %}
+
+        {{ govukInsetText({
+          html: mentorHtml
+        }) }}
+      {% else %}
+        {{ govukInsetText({
+          text: "You can only claim for the academic year September 2023 to July 2024."
+        }) }}
+
+        {{ govukButton({
+          text: "Add claim",
+          href: actions.new
+        }) }}
+      {% endif %}
 
       {% if claims.length %}
         {% include "_includes/claims/list.njk" %}

--- a/app/views/mentors/find.njk
+++ b/app/views/mentors/find.njk
@@ -40,7 +40,7 @@
 
         {{ govukDetails({
           summaryText: "Help with the teacher reference number (TRN)",
-          html: 'If you don’t have a TRN, read the <a href="https://www.gov.uk/guidance/teacher-reference-number-trn" rel="noreferrer noopener" target="_blank">Teacher reference number (TRN) guidance (opens in new tab)</a> to find a lost TRN, or apply for one.'
+          html: 'If you don’t have a TRN, read the <a href="https://www.gov.uk/guidance/teacher-reference-number-trn" rel="noreferrer noopener" target="_blank">teacher reference number (TRN) guidance (opens in new tab)</a> to find a lost TRN, or apply for one.'
         }) }}
 
         {{ govukButton({

--- a/app/views/mentors/find.njk
+++ b/app/views/mentors/find.njk
@@ -40,7 +40,7 @@
 
         {{ govukDetails({
           summaryText: "Help with the teacher reference number (TRN)",
-          html: 'If you don’t have a TRN, read the <a href="https://www.gov.uk/guidance/teacher-reference-number-trn">Teacher reference number (TRN) guidance</a> to find a lost TRN, or apply for one.'
+          html: 'If you don’t have a TRN, read the <a href="https://www.gov.uk/guidance/teacher-reference-number-trn" rel="noreferrer noopener" target="_blank">Teacher reference number (TRN) guidance (opens in new tab)</a> to find a lost TRN, or apply for one.'
         }) }}
 
         {{ govukButton({

--- a/app/views/support/organisations/_no-results.njk
+++ b/app/views/support/organisations/_no-results.njk
@@ -36,7 +36,7 @@
 
     {%- else -%}
 
-      There are no results
+      There are no organisations in {{ serviceName }}
 
     {%- endif -%}
 

--- a/app/views/support/organisations/list.njk
+++ b/app/views/support/organisations/list.njk
@@ -44,11 +44,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {% include "./_search-panel.njk" %}
-
-      {# {% include "./_sort-options.njk" %} #}
-
       {% if organisations.length %}
+
+        {% include "./_search-panel.njk" %}
+
+        {# {% include "./_sort-options.njk" %} #}
 
         <ul class="app-search-results">
           {% for organisation in organisations %}

--- a/app/views/support/organisations/mentors/find.njk
+++ b/app/views/support/organisations/mentors/find.njk
@@ -41,7 +41,7 @@
 
         {{ govukDetails({
           summaryText: "Help with the teacher reference number (TRN)",
-          html: 'If you don’t have a TRN, read the <a href="https://www.gov.uk/guidance/teacher-reference-number-trn">Teacher reference number (TRN) guidance</a> to find a lost TRN, or apply for one.'
+          html: 'If you don’t have a TRN, read the <a href="https://www.gov.uk/guidance/teacher-reference-number-trn" rel="noreferrer noopener" target="_blank">Teacher reference number (TRN) guidance (opens in new tab)</a> to find a lost TRN, or apply for one.'
         }) }}
 
         {{ govukButton({

--- a/app/views/support/organisations/mentors/find.njk
+++ b/app/views/support/organisations/mentors/find.njk
@@ -41,7 +41,7 @@
 
         {{ govukDetails({
           summaryText: "Help with the teacher reference number (TRN)",
-          html: 'If you don’t have a TRN, read the <a href="https://www.gov.uk/guidance/teacher-reference-number-trn" rel="noreferrer noopener" target="_blank">Teacher reference number (TRN) guidance (opens in new tab)</a> to find a lost TRN, or apply for one.'
+          html: 'If you don’t have a TRN, read the <a href="https://www.gov.uk/guidance/teacher-reference-number-trn" rel="noreferrer noopener" target="_blank">teacher reference number (TRN) guidance (opens in new tab)</a> to find a lost TRN, or apply for one.'
         }) }}
 
         {{ govukButton({


### PR DESCRIPTION
- show inset text to alert the user to the need to add a mentor if none in the service
- change the TRN guidance link to open in a new tab
- hide search if no organisations in support