### PR TITLE
Set-up .env if it doesn't exist

### DIFF
--- a/lib/template.env
+++ b/lib/template.env
@@ -1,0 +1,24 @@
+# =========================================
+# WARNING: Don't commit this file to git
+# =========================================
+#
+# Use this file for storing private data - things like API keys and admin credentials
+#
+# Storing data:
+#
+# EXAMPLE_API_KEY=123456789
+# JSON={"foo": "bar"}
+#
+# More examples here: https://www.npmjs.com/package/dotenv
+#
+# Use the data in your app:
+#
+# var key = process.env.EXAMPLE_API_KEY
+
+# =========================================
+# INSERT YOUR DATA HERE:
+
+USE_LOGIN=false
+USE_LOGIN_FALLBACK=false
+SHOW_START_PAGE=false
+PHASE_TAG_TEXT=prototype

--- a/scripts/generate-data.js
+++ b/scripts/generate-data.js
@@ -48,3 +48,15 @@ const remove = (destination) => {
 remove(destinationDirectory)
 
 copy(sourceDirectory, destinationDirectory)
+
+/// ------------------------------------------------------------------------ ///
+/// Environment variables
+/// ------------------------------------------------------------------------ ///
+
+// Create template .env file if it doesn't exist
+const envExists = fs.existsSync(path.join(__dirname, '../.env'))
+
+if (!envExists) {
+  fs.createReadStream(path.join(__dirname, '../lib/template.env'))
+    .pipe(fs.createWriteStream(path.join(__dirname, '../.env')))
+}


### PR DESCRIPTION
We use the `.env` file to manage environment variables and configure the prototype.

This change automatically generates the `.env` file if it doesn't exist.