### PR TITLE
Update contact email address

### DIFF
--- a/app/content/accessibility.md
+++ b/app/content/accessibility.md
@@ -28,7 +28,7 @@ The service was designed using the [GOV.UK design system](https://design-system.
 
 ## Reporting accessibility problems with Claim funding for mentors
 
-If you think we’re not meeting accessibility requirements, or you’d like to access any information in a different format (such as accessible PDF, large print, easy read, audio recording or braille), contact [ittmentor.funding@digital.education.gov.uk](mailto:ittmentor.funding@digital.education.gov.uk). Include ‘Accessibility issues’ in the subject line of your email.
+If you think we’re not meeting accessibility requirements, or you’d like to access any information in a different format (such as accessible PDF, large print, easy read, audio recording or braille), contact [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk). Include ‘Accessibility issues’ in the subject line of your email.
 
 ## Enforcement procedure
 

--- a/app/content/accessibility.md
+++ b/app/content/accessibility.md
@@ -28,7 +28,7 @@ The service was designed using the [GOV.UK design system](https://design-system.
 
 ## Reporting accessibility problems with Claim funding for mentors
 
-If you think we’re not meeting accessibility requirements, or you’d like to access any information in a different format (such as accessible PDF, large print, easy read, audio recording or braille), contact [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk). Include ‘Accessibility issues’ in the subject line of your email.
+If you think we’re not meeting accessibility requirements, or you’d like to access any information in a different format (such as accessible PDF, large print, easy read, audio recording or braille), contact [ittmentor.funding@digital.education.gov.uk](mailto:ittmentor.funding@digital.education.gov.uk). Include ‘Accessibility issues’ in the subject line of your email.
 
 ## Enforcement procedure
 

--- a/app/content/privacy.md
+++ b/app/content/privacy.md
@@ -75,7 +75,7 @@ You can find more information about how we handle personal data in our [personal
 
 ## Getting help and raising a concern
 
-If you would like to exercise any of your rights, you can email us at [ittmentor.funding@digital.education.gov.uk](mailto:ittmentor.funding@digital.education.gov.uk).
+If you would like to exercise any of your rights, you can email us at [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk).
 
 You can also use our [contact form](https://form.education.gov.uk/) to get in touch with our Data Protection Officer.
 

--- a/app/content/privacy.md
+++ b/app/content/privacy.md
@@ -75,7 +75,7 @@ You can find more information about how we handle personal data in our [personal
 
 ## Getting help and raising a concern
 
-If you would like to exercise any of your rights, you can email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+If you would like to exercise any of your rights, you can email us at [ittmentor.funding@digital.education.gov.uk](mailto:ittmentor.funding@digital.education.gov.uk).
 
 You can also use our [contact form](https://form.education.gov.uk/) to get in touch with our Data Protection Officer.
 

--- a/app/content/terms.md
+++ b/app/content/terms.md
@@ -14,7 +14,7 @@ If we change these General Terms we will post the revised document here with an 
 
 This Service is operated by the Department for Education (“we”, “our”, or “us”). We are a central government department and have our registered office at Sanctuary Buildings, 20 Great Smith Street, SW1P 3BT.
 
-You can contact us using the following email address: [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+You can contact us using the following email address: [ittmentor.funding@digital.education.gov.uk](mailto:ittmentor.funding@digital.education.gov.uk)
 
 ## Access to the Service
 

--- a/app/content/terms.md
+++ b/app/content/terms.md
@@ -14,7 +14,7 @@ If we change these General Terms we will post the revised document here with an 
 
 This Service is operated by the Department for Education (“we”, “our”, or “us”). We are a central government department and have our registered office at Sanctuary Buildings, 20 Great Smith Street, SW1P 3BT.
 
-You can contact us using the following email address: [ittmentor.funding@digital.education.gov.uk](mailto:ittmentor.funding@digital.education.gov.uk)
+You can contact us using the following email address: [ittmentor.funding@education.gov.uk](mailto:ittmentor.funding@education.gov.uk)
 
 ## Access to the Service
 

--- a/app/views/_includes/footer.njk
+++ b/app/views/_includes/footer.njk
@@ -14,8 +14,8 @@
         Email
       </h3>
       <p class="govuk-!-font-size-16 govuk-!-margin-bottom-1">
-        <a class="govuk-footer__link" href="mailto:ittmentor.funding@digital.education.gov.uk">
-          ittmentor.funding@digital.education.gov.uk
+        <a class="govuk-footer__link" href="mailto:ittmentor.funding@education.gov.uk">
+          ittmentor.funding@education.gov.uk
         </a>
       </p>
       <p class="govuk-!-font-size-16">You’ll get a response within 5 working days, or one working day for urgent requests.</p>

--- a/app/views/_includes/footer.njk
+++ b/app/views/_includes/footer.njk
@@ -14,8 +14,8 @@
         Email
       </h3>
       <p class="govuk-!-font-size-16 govuk-!-margin-bottom-1">
-        <a class="govuk-footer__link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Publish%20teacher%20training%20courses%20support">
-          becomingateacher@digital.education.gov.uk
+        <a class="govuk-footer__link" href="mailto:ittmentor.funding@digital.education.gov.uk">
+          ittmentor.funding@digital.education.gov.uk
         </a>
       </p>
       <p class="govuk-!-font-size-16">You’ll get a response within 5 working days, or one working day for urgent requests.</p>

--- a/app/views/start.njk
+++ b/app/views/start.njk
@@ -75,7 +75,7 @@
       </p>
 
       <p class="govuk-body">
-        If your organisation has not been set up to claim funding for mentor training, send an email to <a href="mailto:becomingateacher@digital.education.gov.uk" class="govuk-link">becomingateacher@digital.education.gov.uk</a>.
+        If your organisation has not been set up to claim funding for mentor training, send an email to <a href="mailto:ittmentor.funding@digital.education.gov.uk" class="govuk-link">ittmentor.funding@digital.education.gov.uk</a>.
       </p>
 
     </div>

--- a/app/views/start.njk
+++ b/app/views/start.njk
@@ -75,7 +75,7 @@
       </p>
 
       <p class="govuk-body">
-        If your organisation has not been set up to claim funding for mentor training, send an email to <a href="mailto:ittmentor.funding@digital.education.gov.uk" class="govuk-link">ittmentor.funding@digital.education.gov.uk</a>.
+        If your organisation has not been set up to claim funding for mentor training, send an email to <a href="mailto:ittmentor.funding@education.gov.uk" class="govuk-link">ittmentor.funding@education.gov.uk</a>.
       </p>
 
     </div>


### PR DESCRIPTION
Change email address from `becomingateacher@digital.education.gov.uk` to `ittmentor.funding@education.gov.uk`