### PR TITLE
Add submit claim flow [for discussion]

### DIFF
--- a/app/assets/sass/utilities/_overrides.scss
+++ b/app/assets/sass/utilities/_overrides.scss
@@ -9,3 +9,8 @@
 .govuk-phase-banner--no-border-bottom {
   border-bottom: 0;
 }
+
+h1 .govuk-tag {
+  position: relative;
+  top: -7px;
+}

--- a/app/controllers/claims.js
+++ b/app/controllers/claims.js
@@ -40,8 +40,7 @@ exports.claim_list = (req, res) => {
     actions: {
       new: `/organisations/${req.params.organisationId}/claims/new`,
       view: `/organisations/${req.params.organisationId}/claims`,
-      mentors: `/organisations/${req.params.organisationId}/mentors`,
-      check: `/organisations/${req.params.organisationId}/claims/check`
+      mentors: `/organisations/${req.params.organisationId}/mentors`
     }
   })
 }
@@ -425,27 +424,4 @@ exports.delete_claim_post = (req, res) => {
 
   req.flash('success', 'Claim deleted')
   res.redirect(`/organisations/${req.params.organisationId}/claims`)
-}
-
-/// ------------------------------------------------------------------------ ///
-/// CHECK DRAFT CLAIM
-/// ------------------------------------------------------------------------ ///
-
-exports.draft_claim_check_get = (req, res) => {
-  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
-  const claim = claimModel.findOne({
-    organisationId: req.params.organisationId,
-    claimId: req.params.claimId
-  })
-
-  res.render('../views/claims/check-your-answers', {
-    organisation,
-    claim,
-    actions: {
-      save: `/organisations/${req.params.organisationId}/claims/${req.params.claimId}/confirmation`,
-      delete: `/organisations/${req.params.organisationId}/claims/${req.params.claimId}/delete`,
-      back: `/organisations/${req.params.organisationId}/claims/`,
-      cancel: `/organisations/${req.params.organisationId}/claims`
-    }
-  })
 }

--- a/app/controllers/claims.js
+++ b/app/controllers/claims.js
@@ -64,7 +64,7 @@ exports.claim_details = (req, res) => {
       delete: `/organisations/${req.params.organisationId}/claims/${req.params.claimId}/delete`,
       back: `/organisations/${req.params.organisationId}/claims`,
       cancel: `/organisations/${req.params.organisationId}/claims`,
-      submit: '#'
+      submit: `/organisations/${req.params.organisationId}/claims/${req.params.claimId}/check`
     }
   })
 }
@@ -334,8 +334,7 @@ exports.new_claim_check_post = (req, res) => {
 
   delete req.session.data.claim
 
-  // route based on button clicked - submit vs save
-
+  // TODO: route based on button clicked - submit vs save
   // req.flash('success', 'Claim added')
 
   res.redirect(`/organisations/${req.params.organisationId}/claims/${claim.id}/confirmation`)
@@ -353,6 +352,46 @@ exports.new_claim_confirmation_get = (req, res) => {
       back: `/organisations/${req.params.organisationId}/claims`
     }
   })
+}
+
+/// ------------------------------------------------------------------------ ///
+/// EDIT CLAIM
+/// ------------------------------------------------------------------------ ///
+
+exports.edit_claim_check_get = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+  const claim = claimModel.findOne({ claimId: req.params.claimId })
+
+  req.session.data.claim = claim
+
+  res.render('../views/claims/check-your-answers', {
+    organisation,
+    claim: req.session.data.claim,
+    actions: {
+      save: `/organisations/${req.params.organisationId}/claims/${req.params.claimId}/check`,
+      back: `/organisations/${req.params.organisationId}/claims/${req.params.claimId}`,
+      change: `/organisations/${req.params.organisationId}/claims/${req.params.claimId}`,
+      cancel: `/organisations/${req.params.organisationId}/claims/${req.params.claimId}`
+    }
+  })
+}
+
+exports.edit_claim_check_post = (req, res) => {
+  req.session.data.claim.status = 'submitted'
+
+  claimModel.updateOne({
+    organisationId: req.params.organisationId,
+    claimId: req.params.claimId,
+    userId: req.session.passport.user.id,
+    claim: req.session.data.claim
+  })
+
+  delete req.session.data.claim
+
+  // TODO: route based on button clicked - submit vs save
+  // req.flash('success', 'Claim updated')
+
+  res.redirect(`/organisations/${req.params.organisationId}/claims/${req.params.claimId}/confirmation`)
 }
 
 /// ------------------------------------------------------------------------ ///

--- a/app/models/claims.js
+++ b/app/models/claims.js
@@ -134,7 +134,7 @@ exports.updateOne = (params) => {
 
     claim.updatedAt = new Date()
 
-    const filePath = directoryPath + '/' + claim.id + '.json'
+    const filePath = directoryPath + '/' + params.claimId + '.json'
 
     // create a JSON sting for the submitted data
     const fileData = JSON.stringify(claim)

--- a/app/routes.js
+++ b/app/routes.js
@@ -234,8 +234,6 @@ router.get('/organisations/:organisationId/claims/:claimId', checkIsAuthenticate
 
 router.get('/organisations/:organisationId/claims', checkIsAuthenticated, claimController.claim_list)
 
-router.get('/organisations/:organisationId/claims/check/:claimId', checkIsAuthenticated, claimController.draft_claim_check_get)
-
 /// ------------------------------------------------------------------------ ///
 /// ------------------------------------------------------------------------ ///
 /// SUPPORT ROUTES

--- a/app/routes.js
+++ b/app/routes.js
@@ -224,6 +224,9 @@ router.post('/organisations/:organisationId/claims/new/check', checkIsAuthentica
 
 router.get('/organisations/:organisationId/claims/:claimId/confirmation', checkIsAuthenticated, claimController.new_claim_confirmation_get)
 
+router.get('/organisations/:organisationId/claims/:claimId/check', checkIsAuthenticated, claimController.edit_claim_check_get)
+router.post('/organisations/:organisationId/claims/:claimId/check', checkIsAuthenticated, claimController.edit_claim_check_post)
+
 router.get('/organisations/:organisationId/claims/:claimId/delete', checkIsAuthenticated, claimController.delete_claim_get)
 router.post('/organisations/:organisationId/claims/:claimId/delete', checkIsAuthenticated, claimController.delete_claim_post)
 

--- a/app/views/_includes/claims/details.njk
+++ b/app/views/_includes/claims/details.njk
@@ -28,7 +28,7 @@
       actions: {
         items: [
           {
-            href: actions.change + "?referrer=check",
+            href: "#",
             text: "Change",
             visuallyHiddenText: "accredited provider"
           }
@@ -45,7 +45,7 @@
       actions: {
         items: [
           {
-            href: actions.change + "/mentors?referrer=check",
+            href: "#",
             text: "Change",
             visuallyHiddenText: "mentors included in the claim"
           }

--- a/app/views/_includes/claims/details.njk
+++ b/app/views/_includes/claims/details.njk
@@ -51,7 +51,11 @@
           }
         ]
       } if claim.status == "draft"
-    },
+    }
+  ]
+}) }}
+
+{# ,
     {
       key: {
         text: "Status"
@@ -78,6 +82,4 @@
       value: {
         text: claim.submittedAt | datetime('dd MMMM yyyy') if claim.submittedAt else "-"
       }
-    }
-  ]
-}) }}
+    } #}

--- a/app/views/_includes/claims/hours-of-training.njk
+++ b/app/views/_includes/claims/hours-of-training.njk
@@ -15,7 +15,7 @@
       </dd>
       {% if claim.status == "draft" %}
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="{{ actions.change }}/hours?referrer=check&position={{ loop.index0 }}">
+          <a class="govuk-link" href="#"> {# {{ actions.change }}/hours?referrer=check&position={{ loop.index0 }} #}
             Change<span class="govuk-visually-hidden"> hours of training undertaken by {{ mentor.trn | getMentorName }}</span>
           </a>
         </dd>

--- a/app/views/_includes/claims/list.njk
+++ b/app/views/_includes/claims/list.njk
@@ -13,15 +13,9 @@
     {% for claim in claims %}
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
-          {% if claim.status === "draft" %}
-          <a class="govuk-link" href="{{ actions.check }}/{{ claim.id }}">
-            {{ claim.reference | upper }}
-          </a>
-          {% else %}
           <a class="govuk-link" href="{{ actions.view }}/{{ claim.id }}">
             {{ claim.reference | upper }}
           </a>
-          {% endif %}
         </td>
         <td class="govuk-table__cell">
           {{ claim.providerId | getProviderName }}

--- a/app/views/claims/check-your-answers.njk
+++ b/app/views/claims/check-your-answers.njk
@@ -3,7 +3,11 @@
 {% set primaryNavId = "claims" %}
 
 {% set title = "Check your answers" %}
-{% set caption = "Add claim" %}
+{% if claim.id %}
+  {% set caption = "Claim - " + claim.reference %}
+{% else %}
+  {% set caption = "Add claim" %}
+{% endif %}
 
 {% block pageTitle %}
   {{ "Error: " if errors.length }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
@@ -50,12 +54,12 @@
                 text: "Accredited provider"
               },
               value: {
-                text: claim.provider | getProviderName
+                text: claim.providerId | getProviderName
               },
               actions: {
                 items: [
                   {
-                    href: actions.change + "?referrer=check",
+                    href: "#",
                     text: "Change",
                     visuallyHiddenText: "accredited provider"
                   }

--- a/app/views/claims/confirmation.njk
+++ b/app/views/claims/confirmation.njk
@@ -25,10 +25,9 @@
         html: "Your reference number<br><strong>" + claim.reference | upper + "</strong>"
       }) }}
 
+      <p class="govuk-body">We have emailed you a copy of your claim.</p>
 
       <h2 class="govuk-heading-m">What happens next</h2>
-
-      <p class="govuk-body">We have emailed you a copy of your claim.</p>
 
       <p class="govuk-body">
         We will check your claim before processing payment. If we need to contact you for further information, we will use the email you used to access this service.

--- a/app/views/claims/list.njk
+++ b/app/views/claims/list.njk
@@ -28,15 +28,17 @@
           html: mentorHtml
         }) }}
 
-        {% endif %}
+      {% else %}
 
-      <p class="govuk-body">
+        <p class="govuk-body">
           Claims can only be made for the school year September 2023 to July 2024.
         </p>
 
-      <p class="govuk-body">
+        <p class="govuk-body">
           The final date to submit a claim is 19 July 2024.
         </p>
+
+      {% endif %}
 
       {% if mentors.length %}
         {{ govukButton({
@@ -48,7 +50,7 @@
       {% if claims.length %}
         {% include "_includes/claims/list.njk" %}
         {% include "_includes/pagination.njk" %}
-      {% elseif mentors.length %}
+      {% else %}
         <p class="govuk-body">There are no claims for {{ organisation.name if organisation.name else "your organisation" }}.</p>
       {% endif %}
 

--- a/app/views/claims/provider.njk
+++ b/app/views/claims/provider.njk
@@ -42,7 +42,7 @@
             },
             {
               value: "15ca4914-3505-41a1-80ea-5a0312c8ead4",
-              text: "NIoT: National Institute of Teaching, founded by the School-Led Development Trust"
+              text: "National Institute of Teaching (NIoT)"
             }
           ],
           errorMessage: errors | getErrorMessage("provider")

--- a/app/views/claims/show.njk
+++ b/app/views/claims/show.njk
@@ -20,13 +20,26 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {% include "_includes/page-heading.njk" %}
+      <h1 class="govuk-heading-l">
+        {% if caption.length %}
+          <span class="govuk-caption-l">
+            {{ caption }}
+          </span>
+        {% endif %}
+        {{ title }}
+        {{ govukTag({
+          text: claim.status | capitalize,
+          classes: "" + claim.status | getClaimStatusClasses
+        }) }}
+      </h1>
 
       {% if claim.status == "draft" %}
         {{ govukButton({
           text: "Submit claim",
           href: actions.submit
         }) }}
+      {% else %}
+        <p class="govuk-body">Submitted by {{ claim.submittedBy | getUserName }} on {{ claim.submittedAt | datetime('dd MMMM yyyy') }}.</p>
       {% endif %}
 
       {% include "_includes/claims/details.njk" %}

--- a/app/views/claims/show.njk
+++ b/app/views/claims/show.njk
@@ -22,15 +22,12 @@
 
       {% include "_includes/page-heading.njk" %}
 
-      <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
-
-        {% if claim.status == "draft" %}
-          {{ govukButton({
-            text: "Submit claim"
-          }) }}
-        {% endif %}
-
-      </form>
+      {% if claim.status == "draft" %}
+        {{ govukButton({
+          text: "Submit claim",
+          href: actions.submit
+        }) }}
+      {% endif %}
 
       {% include "_includes/claims/details.njk" %}
 

--- a/app/views/support/organisations/claims/check-your-answers.njk
+++ b/app/views/support/organisations/claims/check-your-answers.njk
@@ -43,7 +43,7 @@
                 text: "Accredited provider"
               },
               value: {
-                text: claim.provider | getProviderName
+                text: claim.providerId | getProviderName
               },
               actions: {
                 items: [

--- a/app/views/support/organisations/claims/provider.njk
+++ b/app/views/support/organisations/claims/provider.njk
@@ -43,7 +43,7 @@
             },
             {
               value: "15ca4914-3505-41a1-80ea-5a0312c8ead4",
-              text: "NIoT: National Institute of Teaching, founded by the School-Led Development Trust"
+              text: "National Institute of Teaching (NIoT)"
             }
           ],
           errorMessage: errors | getErrorMessage("provider")

--- a/app/views/support/organisations/claims/show.njk
+++ b/app/views/support/organisations/claims/show.njk
@@ -22,7 +22,22 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {% include "_includes/page-heading.njk" %}
+      <h1 class="govuk-heading-l">
+        {% if caption.length %}
+          <span class="govuk-caption-l">
+            {{ caption }}
+          </span>
+        {% endif %}
+        {{ title }}
+        {{ govukTag({
+          text: claim.status | capitalize,
+          classes: "" + claim.status | getClaimStatusClasses
+        }) }}
+      </h1>
+
+      {% if claim.status == "submitted" %}
+        <p class="govuk-body">Submitted by {{ claim.submittedBy | getUserName }} on {{ claim.submittedAt | datetime('dd MMMM yyyy') }}.</p>
+      {% endif %}
 
       {% include "_includes/claims/details.njk" %}
 


### PR DESCRIPTION
This PR introduces an alternative 'submit a draft claim' flow.

When a school user clicks on a claim in their claims list, we show the claim details (regardless of status: draft or submitted). 

This means:

- we always show the same thing to the user
- we follow a common pattern - the `list > details` flow matches claims, mentors and users lists across the school user and the support user interfaces, as well as in the Manage school placements, Publish teacher training courses and Manage teacher training applications services
- users don't have to know why one claim page looks different from another
- users can decide what to do next - we don't assume intent (submit vs view)

If the claim has the submitted state, we show the claim with no change links.

If the claim is in draft state, we show a ‘Submit claim’ button below the heading, a summary list with change links, and a ‘Remove claim’ link at the bottom.

Selecting ‘Submit claim’ takes the user to a check your answers page, including change links, with the declaration and a ‘Submit claim’ button at the bottom. It serves as a double confirmation.

Once submitted, we show the claim confirmation page. The user can select ‘View claims’ or ‘Claims’ in the primary navigation. We show the most recently submitted claim at the top of the school’s claims list.

The downside of this approach is that we have partly duplicated screens (the summary lists with change links).

A mitigating factor in private beta is that support users do not want to create claims on behalf of schools, and we don't have a paper-based claim process that requires them to do so. Furthermore, schools can't create draft claims or edit submitted claims. This means this flow is not often seen.