### PR TITLE
Fix providerId variable

### DIFF
--- a/app/views/claims/hours.njk
+++ b/app/views/claims/hours.njk
@@ -3,7 +3,7 @@
 {% set primaryNavId = "claims" %}
 
 {% set title = "Hours of training for " + (mentorTrn | getMentorName) %}
-{% set caption = "Add claim - " + (claim.provider | getProviderName) %}
+{% set caption = "Add claim - " + (claim.providerId | getProviderName) %}
 
 {% block beforeContent %}
 {{ govukBackLink({

--- a/app/views/claims/mentors.njk
+++ b/app/views/claims/mentors.njk
@@ -3,7 +3,7 @@
 {% set primaryNavId = "claims" %}
 
 {% set title = "Mentor" %}
-{% set caption = "Add claim - " + (claim.provider | getProviderName) %}
+{% set caption = "Add claim - " + (claim.providerId | getProviderName) %}
 
 {% block beforeContent %}
 {{ govukBackLink({


### PR DESCRIPTION
In a recent update, we changed the `claim.provider` variable to `claim.providerId`. This makes it clearer what type of data is stored, etc.

This PR fixes a few missing instances where the ID is used.