### PR TITLE
Fix claim status and meta data

### DIFF
--- a/app/views/support/claims/show.njk
+++ b/app/views/support/claims/show.njk
@@ -21,7 +21,22 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {% include "_includes/page-heading.njk" %}
+      <h1 class="govuk-heading-l">
+        {% if caption.length %}
+          <span class="govuk-caption-l">
+            {{ caption }}
+          </span>
+        {% endif %}
+        {{ title }}
+        {{ govukTag({
+          text: claim.status | capitalize,
+          classes: "" + claim.status | getClaimStatusClasses
+        }) }}
+      </h1>
+
+      {% if claim.status == "submitted" %}
+        <p class="govuk-body">Submitted by {{ claim.submittedBy | getUserName }} on {{ claim.submittedAt | datetime('dd MMMM yyyy') }}.</p>
+      {% endif %}
 
       {% include "_includes/claims/details.njk" %}
 


### PR DESCRIPTION
The claim status and submitted by/on meta data are missing from the `Support > Claims` section. This PR fixes the problem.