### PR TITLE
Handling duplicate mentor provider claims

### DIFF
--- a/app/controllers/claims.js
+++ b/app/controllers/claims.js
@@ -222,10 +222,12 @@ exports.new_claim_hours_get = (req, res) => {
   const position = req.session.data.position
   const mentorTrn = req.session.data.mentorChoices[position]
 
-  claimHelper.getProviderMentorTotalHours({
+  const mentorHours = claimHelper.getProviderMentorTotalHours({
     providerId: req.session.data.claim.providerId,
     trn: mentorTrn
   })
+
+  const mentorRemainingHours = 20 - mentorHours
 
   let mentor = req.session.data.mentor
   if (req.query.referrer === 'check') {
@@ -237,6 +239,7 @@ exports.new_claim_hours_get = (req, res) => {
     mentorTrn,
     position,
     mentor,
+    mentorRemainingHours,
     actions: {
       save,
       back,
@@ -255,6 +258,13 @@ exports.new_claim_hours_post = (req, res) => {
 
   const position = req.session.data.position
   const mentorTrn = req.session.data.mentorChoices[position]
+
+  const mentorHours = claimHelper.getProviderMentorTotalHours({
+    providerId: req.session.data.claim.providerId,
+    trn: mentorTrn
+  })
+
+  const mentorRemainingHours = 20 - mentorHours
 
   let mentor = req.session.data.mentor
   if (req.query.referrer === 'check') {
@@ -279,12 +289,12 @@ exports.new_claim_hours_post = (req, res) => {
     } else if (
       isNaN(req.session.data.mentor.otherHours)
       || req.session.data.mentor.otherHours < 1
-      || req.session.data.mentor.otherHours > 20
+      || req.session.data.mentor.otherHours > mentorRemainingHours
     ) {
       const error = {}
       error.fieldName = 'otherHours'
       error.href = '#otherHours'
-      error.text = 'Enter the number of hours between 1 and 20'
+      error.text = `Enter the number of hours between 1 and ${mentorRemainingHours}`
       errors.push(error)
     }
     // else if (!Number.isInteger(req.session.data.mentor.otherHours)) {
@@ -302,6 +312,7 @@ exports.new_claim_hours_post = (req, res) => {
       mentorTrn,
       position,
       mentor,
+      mentorRemainingHours,
       actions: {
         save,
         back,

--- a/app/controllers/claims.js
+++ b/app/controllers/claims.js
@@ -277,7 +277,7 @@ exports.new_claim_hours_post = (req, res) => {
     const error = {}
     error.fieldName = 'hours'
     error.href = '#hours'
-    error.text = 'Select the number of hours'
+    error.text = 'Select the hours of training'
     errors.push(error)
   } else if (req.session.data.mentor.hours === 'other') {
     if (!req.session.data.mentor.otherHours.length) {

--- a/app/controllers/claims.js
+++ b/app/controllers/claims.js
@@ -129,11 +129,27 @@ exports.new_claim_post = (req, res) => {
 }
 
 exports.new_claim_mentors_get = (req, res) => {
-  const mentorOptions = mentorHelper.getMentorOptions({ organisationId: req.params.organisationId })
+  const mentorsCount = mentorModel.findMany({ organisationId: req.params.organisationId }).length
+  let mentorOptions = mentorHelper.getMentorOptions({ organisationId: req.params.organisationId })
+
+  mentorOptions = mentorOptions.filter(mentor => {
+    const mentorHours = claimHelper.getProviderMentorTotalHours({
+      providerId: req.session.data.claim.providerId,
+      trn: mentor.value
+    })
+
+    if (mentorHours < 20) {
+      return mentor
+    }
+  })
+
+  const mentorOptionsCount = mentorOptions.length
 
   res.render('../views/claims/mentors', {
     claim: req.session.data.claim,
+    mentorsCount,
     mentorOptions,
+    mentorOptionsCount,
     mentorChoices: req.session.data.mentorChoices,
     actions: {
       save: `/organisations/${req.params.organisationId}/claims/new/mentors`,
@@ -144,7 +160,21 @@ exports.new_claim_mentors_get = (req, res) => {
 }
 
 exports.new_claim_mentors_post = (req, res) => {
-  const mentorOptions = mentorHelper.getMentorOptions({ organisationId: req.params.organisationId })
+  const mentorsCount = mentorModel.findMany({ organisationId: req.params.organisationId }).length
+  let mentorOptions = mentorHelper.getMentorOptions({ organisationId: req.params.organisationId })
+
+  mentorOptions = mentorOptions.filter(mentor => {
+    const mentorHours = claimHelper.getProviderMentorTotalHours({
+      providerId: req.session.data.claim.providerId,
+      trn: mentor.value
+    })
+
+    if (mentorHours < 20) {
+      return mentor
+    }
+  })
+
+  const mentorOptionsCount = mentorOptions.length
 
   const errors = []
 
@@ -159,7 +189,9 @@ exports.new_claim_mentors_post = (req, res) => {
   if (errors.length) {
     res.render('../views/claims/mentors', {
       claim: req.session.data.claim,
+      mentorsCount,
       mentorOptions,
+      mentorOptionsCount,
       mentorChoices: req.session.data.mentorChoices,
       actions: {
         save: `/organisations/${req.params.organisationId}/claims/new/mentors`,
@@ -189,6 +221,11 @@ exports.new_claim_hours_get = (req, res) => {
 
   const position = req.session.data.position
   const mentorTrn = req.session.data.mentorChoices[position]
+
+  claimHelper.getProviderMentorTotalHours({
+    providerId: req.session.data.claim.providerId,
+    trn: mentorTrn
+  })
 
   let mentor = req.session.data.mentor
   if (req.query.referrer === 'check') {

--- a/app/helpers/claims.js
+++ b/app/helpers/claims.js
@@ -1,3 +1,5 @@
+const claimModel = require('../models/claims')
+
 const fundingHelper = require('./funding')
 
 exports.generateClaimID = () => {
@@ -48,4 +50,30 @@ exports.getClaimStatusClasses = (status) => {
   }
 
   return classes
+}
+
+exports.getProviderMentorTotalHours = (params) => {
+  let totalHours = 0
+
+  if (params.providerId && params.trn) {
+    const claims = claimModel.findMany({ providerId: params.providerId })
+
+    const mentorClaims = claims.filter(claim => {
+      return claim.mentors.find(mentor => parseInt(mentor.trn) === parseInt(params.trn))
+    })
+
+    mentorClaims.forEach(claim => {
+      claim?.mentors.forEach(mentor => {
+        if (parseInt(mentor.trn) === parseInt(params.trn)) {
+          if (mentor.hours === 'other') {
+            totalHours += parseInt(mentor.otherHours)
+          } else {
+            totalHours += parseInt(mentor.hours)
+          }
+        }
+      })
+    })
+  }
+
+  return totalHours
 }

--- a/app/models/claims.js
+++ b/app/models/claims.js
@@ -23,8 +23,14 @@ exports.findMany = (params) => {
     claims.push(data)
   })
 
+  // School
   if (params.organisationId) {
     claims = claims.filter(claim => claim.organisationId === params.organisationId)
+  }
+
+  // Accredited provider
+  if (params.providerId) {
+    claims = claims.filter(claim => claim.providerId === params.providerId)
   }
 
   return claims

--- a/app/views/claims/hours.njk
+++ b/app/views/claims/hours.njk
@@ -26,7 +26,8 @@
         Show the number of remaining hours in the message and options
       #}
       {% set insetHtml %}
-        <p>There are 20 hours left to claim for {{ mentorTrn | getMentorName }} for {{ claim.providerId | getProviderName }}.</p><p>Contact <a href='mailto:ittmentor.funding@ducation.gov.uk'>ittmentor.funding@ducation.gov.uk</a> if you think there is a problem.</p>
+        <p class="govuk-body">There are <b>{{ mentorRemainingHours }} hours left to claim</b> for {{ mentorTrn | getMentorName }} for {{ claim.providerId | getProviderName }}.</p>
+        <p class="govuk-body">Contact <a class="govuk-link" href="mailto:ittmentor.funding@ducation.gov.uk">ittmentor.funding@ducation.gov.uk</a> if you think there is a problem.</p>
       {% endset %}
 
       {{ govukInsetText({
@@ -49,10 +50,10 @@
           value: mentor.hours,
           items: [
             {
-              value: "20",
-              text: "20 hours",
+              value: mentorRemainingHours,
+              text: mentorRemainingHours + " hours",
               hint: {
-                text: "The full amount of hours for standard training"
+                text: "The " + ("standard" if mentorRemainingHours == 20 else "remaining") + " amount of hours for standard training"
               }
             },
             {
@@ -78,7 +79,7 @@
                     classes: "govuk-label--s"
                   },
                   hint: {
-                    text: "Enter whole numbers up to a maximum of 20 hours"
+                    text: "Enter whole numbers up to a maximum of " + mentorRemainingHours + " hours"
                   },
                   value: mentor.otherHours,
                   errorMessage: errors | getErrorMessage("otherHours"),

--- a/app/views/claims/hours.njk
+++ b/app/views/claims/hours.njk
@@ -19,27 +19,29 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {% include "_includes/page-heading.njk" %}
-
-      {% set insetHtml %}
-        <p class="govuk-body">There are <b>{{ mentorRemainingHours }} hours left to claim</b> for {{ mentorTrn | getMentorName }} for {{ claim.providerId | getProviderName }}.</p>
-        <p class="govuk-body">Contact <a href="mailto:ittmentor.funding@ducation.gov.uk" class="govuk-link">ittmentor.funding@ducation.gov.uk</a> if you think there is a problem.</p>
-      {% endset %}
-
-      {{ govukInsetText({
-        html: insetHtml
-      }) }}
-
       <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
         <input type="hidden" name="mentor[trn]" value="{{ mentorTrn }}">
         <input type="hidden" name="mentor[name]" value="{{ mentorTrn | getMentorName }}">
+
+      {% if mentorRemainingHours < 20 %}
+
+        {% include "_includes/page-heading.njk" %}
+
+        {% set insetHtml %}
+          <p class="govuk-body">There are <b>{{ mentorRemainingHours }} hours left to claim</b> for {{ mentorTrn | getMentorName }} for {{ claim.providerId | getProviderName }}.</p>
+          <p class="govuk-body">Contact <a href="mailto:ittmentor.funding@ducation.gov.uk" class="govuk-link">ittmentor.funding@ducation.gov.uk</a> if you think there is a problem.</p>
+        {% endset %}
+
+        {{ govukInsetText({
+          html: insetHtml
+        }) }}
 
         {{ govukRadios({
           name: "mentor[hours]",
           fieldset: {
             legend: {
               text: "Hours of training",
-              isPageHeading: true,
+              isPageHeading: false,
               classes: "govuk-fieldset__legend--s"
             }
           },
@@ -86,6 +88,69 @@
           ],
           errorMessage: errors | getErrorMessage("hours")
         }) }}
+
+      {% else %}
+
+        {% set headingHtml %}
+          {% include "_includes/page-heading-legend.njk" %}
+        {% endset %}
+
+        {{ govukRadios({
+          name: "mentor[hours]",
+          fieldset: {
+            legend: {
+              html: headingHtml,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          value: mentor.hours,
+          items: [
+            {
+              value: mentorRemainingHours,
+              text: mentorRemainingHours + " hours",
+              hint: {
+                text: "The " + ("standard" if mentorRemainingHours == 20 else "remaining") + " amount of hours for standard training"
+              }
+            },
+            {
+              value: "6",
+              text: "6 hours",
+              hint: {
+                text: "The amount of hours for top up training"
+              }
+            } if 1==0,
+            {
+              divider: "or"
+            },
+            {
+              value: "other",
+              text: "Another amount",
+              conditional: {
+                html: govukInput({
+                  id: "otherAmount",
+                  name: "mentor[otherHours]",
+                  label: {
+                    text: "Number of hours",
+                    isPageHeading: false,
+                    classes: "govuk-label--s"
+                  },
+                  hint: {
+                    text: "Enter whole numbers up to a maximum of " + mentorRemainingHours + " hours"
+                  },
+                  value: mentor.otherHours,
+                  errorMessage: errors | getErrorMessage("otherHours"),
+                  classes: "govuk-input--width-2"
+                })
+              }
+            }
+          ],
+          errorMessage: errors | getErrorMessage("hours")
+        }) }}
+
+      {% endif %}
+
+
 
 
         {{ govukButton({

--- a/app/views/claims/hours.njk
+++ b/app/views/claims/hours.njk
@@ -21,6 +21,10 @@
 
       {% include "_includes/page-heading.njk" %}
 
+      {# TODO:
+        Only show if the training hours have been limited
+        Show the number of remaining hours in the message and options
+      #}
       {% set insetHtml %}
         <p>There are 20 hours left to claim for {{ mentorTrn | getMentorName }} for {{ claim.providerId | getProviderName }}.</p><p>Contact <a href='mailto:ittmentor.funding@ducation.gov.uk'>ittmentor.funding@ducation.gov.uk</a> if you think there is a problem.</p>
       {% endset %}

--- a/app/views/claims/hours.njk
+++ b/app/views/claims/hours.njk
@@ -19,9 +19,15 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {% set headingHtml %}
-        {% include "_includes/page-heading-legend.njk" %}
+      {% include "_includes/page-heading.njk" %}
+
+      {% set insetHtml %}
+        <p>There are 20 hours left to claim for {{ mentorTrn | getMentorName }} for {{ claim.providerId | getProviderName }}.</p><p>Contact <a href='mailto:ittmentor.funding@ducation.gov.uk'>ittmentor.funding@ducation.gov.uk</a> if you think there is a problem.</p>
       {% endset %}
+
+      {{ govukInsetText({
+        html: insetHtml
+      }) }}
 
       <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
         <input type="hidden" name="mentor[trn]" value="{{ mentorTrn }}">
@@ -31,9 +37,9 @@
           name: "mentor[hours]",
           fieldset: {
             legend: {
-              html: headingHtml,
+              text: "Hours of training",
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--l"
+              classes: "govuk-fieldset__legend--s"
             }
           },
           value: mentor.hours,

--- a/app/views/claims/hours.njk
+++ b/app/views/claims/hours.njk
@@ -21,13 +21,9 @@
 
       {% include "_includes/page-heading.njk" %}
 
-      {# TODO:
-        Only show if the training hours have been limited
-        Show the number of remaining hours in the message and options
-      #}
       {% set insetHtml %}
         <p class="govuk-body">There are <b>{{ mentorRemainingHours }} hours left to claim</b> for {{ mentorTrn | getMentorName }} for {{ claim.providerId | getProviderName }}.</p>
-        <p class="govuk-body">Contact <a class="govuk-link" href="mailto:ittmentor.funding@ducation.gov.uk">ittmentor.funding@ducation.gov.uk</a> if you think there is a problem.</p>
+        <p class="govuk-body">Contact <a href="mailto:ittmentor.funding@ducation.gov.uk" class="govuk-link">ittmentor.funding@ducation.gov.uk</a> if you think there is a problem.</p>
       {% endset %}
 
       {{ govukInsetText({

--- a/app/views/claims/list.njk
+++ b/app/views/claims/list.njk
@@ -17,28 +17,25 @@
 
       {% include "_includes/page-heading.njk" %}
 
-      {% if not mentors.length %}
-        {% set mentorHtml %}
+      {% set insetHtml %}
+        {% if not mentors.length %}
           <p class="govuk-body">
             Before you can start a claim you will need to <a href="{{ actions.mentors }}" class="govuk-link">add a mentor</a>.
           </p>
-        {% endset %}
+        {% else %}
+          <p class="govuk-body">
+            Claims can only be made for the school year September 2023 to July 2024.
+          </p>
+          <p class="govuk-body">
+            The final date to submit a claim is 19 July 2024.
+          </p>
+        {% endif %}
 
-        {{ govukInsetText({
-          html: mentorHtml
-        }) }}
+      {% endset %}
 
-      {% else %}
-
-        <p class="govuk-body">
-          Claims can only be made for the school year September 2023 to July 2024.
-        </p>
-
-        <p class="govuk-body">
-          The final date to submit a claim is 19 July 2024.
-        </p>
-
-      {% endif %}
+      {{ govukInsetText({
+        html: insetHtml
+      }) }}
 
       {% if mentors.length %}
         {{ govukButton({

--- a/app/views/claims/mentors.njk
+++ b/app/views/claims/mentors.njk
@@ -6,8 +6,8 @@
   {% set title = "No mentors for " + (claim.providerId | getProviderName) %}
   {% set caption = "Add claim" %}
 {% else %}
-  {% set title = "Mentor" %}
-  {% set caption = "Add claim - " + (claim.providerId | getProviderName) %}
+  {% set title = "Mentors for " + (claim.providerId | getProviderName) %}
+  {% set caption = "Add claim" %}
 {% endif %}
 
 {% block beforeContent %}
@@ -41,8 +41,8 @@
             {% include "_includes/page-heading.njk" %}
 
             {% set insetHtml %}
-              <p class="govuk-body">This list includes all mentors who can be included on a claim. If a mentor you have added is not showing in this list, that is because they have already had 20 hours of training claimed for with this provider.</p>
-              <p class="govuk-body">Training may have been claimed for by a different school.</p>
+              <p class="govuk-body">This list includes all mentors who can be included on a claim. If a mentor you have added is not showing in this list, that is because they have already had 20 hours of training claimed for with {{ claim.providerId | getProviderName }}.</p>
+              <p class="govuk-body">Contact <a href="mailto:ittmentor.funding@ducation.gov.uk" class="govuk-link">ittmentor.funding@ducation.gov.uk</a> if you think there is a problem.</p>
             {% endset %}
 
             {{ govukInsetText({
@@ -53,10 +53,13 @@
               name: "mentorChoices[]",
               fieldset: {
                 legend: {
-                  text: "Select the mentors for this claim",
+                  text: "Mentor",
                   isPageHeading: false,
                   classes: "govuk-fieldset__legend--s"
                 }
+              },
+              hint: {
+                text: "Select all that apply"
               },
               values: mentorChoices,
               items: mentorOptions,

--- a/app/views/claims/mentors.njk
+++ b/app/views/claims/mentors.njk
@@ -21,9 +21,14 @@
 
       {% include "_includes/page-heading.njk" %}
 
-      {{ govukDetails({
-        summaryText: "Why are not all mentors shown here?",
-        html: "<p>This list includes all mentors who can be included on a claim. If a mentor you have added is not showing in this list, that is because they have already had 20 hours of training claimed for with this provider.</p><p>Training may have been claimed for by a different school.</p>"
+      {# TODO: Only show if the mentor list has been limited #}
+      {% set insetHtml %}
+        <p class="govuk-body">This list includes all mentors who can be included on a claim. If a mentor you have added is not showing in this list, that is because they have already had 20 hours of training claimed for with this provider.</p>
+        <p class="govuk-body">Training may have been claimed for by a different school.</p>
+      {% endset %}
+
+      {{ govukInsetText({
+        html: insetHtml
       }) }}
 
       <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>

--- a/app/views/claims/mentors.njk
+++ b/app/views/claims/mentors.njk
@@ -19,9 +19,12 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {% set headingHtml %}
-        {% include "_includes/page-heading-legend.njk" %}
-      {% endset %}
+      {% include "_includes/page-heading.njk" %}
+
+      {{ govukDetails({
+        summaryText: "Why are not all mentors shown here?",
+        html: "<p>This list includes all mentors who can be included on a claim. If a mentor you have added is not showing in this list, that is because they have already had 20 hours of training claimed for with this provider.</p><p>Training may have been claimed for by a different school.</p>"
+      }) }}
 
       <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
 
@@ -29,13 +32,10 @@
           name: "mentorChoices[]",
           fieldset: {
             legend: {
-              html: headingHtml,
-              isPageHeading: true,
-              classes: "govuk-fieldset__legend--l"
+              text: "Select the mentors for this claim",
+              isPageHeading: false,
+              classes: "govuk-fieldset__legend--s"
             }
-          },
-          hint: {
-            text: "Select all that apply"
           },
           values: mentorChoices,
           items: mentorOptions,

--- a/app/views/claims/mentors.njk
+++ b/app/views/claims/mentors.njk
@@ -19,22 +19,32 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
-
-        {% if mentorOptionsCount < mentorsCount %}
+      {% if mentorOptionsCount == 0 %}
 
           {% include "_includes/page-heading.njk" %}
 
-          {% set insetHtml %}
-            <p class="govuk-body">This list includes all mentors who can be included on a claim. If a mentor you have added is not showing in this list, that is because they have already had 20 hours of training claimed for with this provider.</p>
-            <p class="govuk-body">Training may have been claimed for by a different school.</p>
-          {% endset %}
+          <p class="govuk-body">There are no mentors you can include in a claim for {{ claim.providerId | getProviderName }} training.</p>
 
-          {{ govukInsetText({
-            html: insetHtml
-          }) }}
+          <p class="govuk-body">Try <a href="{{ actions.back }}" class="govuk-link">changing your accredited provider</a>.</p>
 
-          {{ govukCheckboxes({
+      {% else %}
+
+        <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
+
+          {% if mentorOptionsCount < mentorsCount %}
+
+            {% include "_includes/page-heading.njk" %}
+
+            {% set insetHtml %}
+              <p class="govuk-body">This list includes all mentors who can be included on a claim. If a mentor you have added is not showing in this list, that is because they have already had 20 hours of training claimed for with this provider.</p>
+              <p class="govuk-body">Training may have been claimed for by a different school.</p>
+            {% endset %}
+
+            {{ govukInsetText({
+              html: insetHtml
+            }) }}
+
+            {{ govukCheckboxes({
               name: "mentorChoices[]",
               fieldset: {
                 legend: {
@@ -48,40 +58,42 @@
               errorMessage: errors | getErrorMessage("mentorChoices")
             }) }}
 
-        {% else %}
+          {% else %}
 
-          {% set headingHtml %}
-            {% include "_includes/page-heading-legend.njk" %}
-          {% endset %}
+            {% set headingHtml %}
+              {% include "_includes/page-heading-legend.njk" %}
+            {% endset %}
 
-          {{ govukCheckboxes({
-            name: "mentorChoices[]",
-            fieldset: {
-              legend: {
-                html: headingHtml,
-                isPageHeading: true,
-                classes: "govuk-fieldset__legend--l"
-              }
-            },
-            hint: {
-              text: "Select all that apply"
-            },
-            values: mentorChoices,
-            items: mentorOptions,
-            errorMessage: errors | getErrorMessage("mentorChoices")
+            {{ govukCheckboxes({
+              name: "mentorChoices[]",
+              fieldset: {
+                legend: {
+                  html: headingHtml,
+                  isPageHeading: true,
+                  classes: "govuk-fieldset__legend--l"
+                }
+              },
+              hint: {
+                text: "Select all that apply"
+              },
+              values: mentorChoices,
+              items: mentorOptions,
+              errorMessage: errors | getErrorMessage("mentorChoices")
+            }) }}
+
+          {% endif %}
+
+          {{ govukButton({
+            text: "Continue"
           }) }}
 
-        {% endif %}
+        </form>
 
-        {{ govukButton({
-          text: "Continue"
-        }) }}
+        <p class="govuk-body">
+          <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
+        </p>
 
-      </form>
-
-      <p class="govuk-body">
-        <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
-      </p>
+      {% endif %}
 
     </div>
   </div>

--- a/app/views/claims/mentors.njk
+++ b/app/views/claims/mentors.njk
@@ -2,8 +2,13 @@
 
 {% set primaryNavId = "claims" %}
 
-{% set title = "Mentor" %}
-{% set caption = "Add claim - " + (claim.providerId | getProviderName) %}
+{% if mentorOptionsCount == 0 %}
+  {% set title = "No mentors for " + (claim.providerId | getProviderName) %}
+  {% set caption = "Add claim" %}
+{% else %}
+  {% set title = "Mentor" %}
+  {% set caption = "Add claim - " + (claim.providerId | getProviderName) %}
+{% endif %}
 
 {% block beforeContent %}
 {{ govukBackLink({
@@ -23,9 +28,9 @@
 
           {% include "_includes/page-heading.njk" %}
 
-          <p class="govuk-body">There are no mentors you can include in a claim for {{ claim.providerId | getProviderName }} training.</p>
+          <p class="govuk-body">There are no mentors you can include in a claim because they have already had 20 hours of training claimed for with {{ claim.providerId | getProviderName }}.</p>
 
-          <p class="govuk-body">Try <a href="{{ actions.back }}" class="govuk-link">changing your accredited provider</a>.</p>
+          <p class="govuk-body"><a href="{{ actions.back }}" class="govuk-link">Change the accredited provider</a></p>
 
       {% else %}
 

--- a/app/views/claims/mentors.njk
+++ b/app/views/claims/mentors.njk
@@ -19,33 +19,59 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {% include "_includes/page-heading.njk" %}
-
-      {# TODO: Only show if the mentor list has been limited #}
-      {% set insetHtml %}
-        <p class="govuk-body">This list includes all mentors who can be included on a claim. If a mentor you have added is not showing in this list, that is because they have already had 20 hours of training claimed for with this provider.</p>
-        <p class="govuk-body">Training may have been claimed for by a different school.</p>
-      {% endset %}
-
-      {{ govukInsetText({
-        html: insetHtml
-      }) }}
-
       <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
 
-        {{ govukCheckboxes({
-          name: "mentorChoices[]",
-          fieldset: {
-            legend: {
-              text: "Select the mentors for this claim",
-              isPageHeading: false,
-              classes: "govuk-fieldset__legend--s"
-            }
-          },
-          values: mentorChoices,
-          items: mentorOptions,
-          errorMessage: errors | getErrorMessage("mentorChoices")
-        }) }}
+        {% if mentorOptionsCount < mentorsCount %}
+
+          {% include "_includes/page-heading.njk" %}
+
+          {% set insetHtml %}
+            <p class="govuk-body">This list includes all mentors who can be included on a claim. If a mentor you have added is not showing in this list, that is because they have already had 20 hours of training claimed for with this provider.</p>
+            <p class="govuk-body">Training may have been claimed for by a different school.</p>
+          {% endset %}
+
+          {{ govukInsetText({
+            html: insetHtml
+          }) }}
+
+          {{ govukCheckboxes({
+              name: "mentorChoices[]",
+              fieldset: {
+                legend: {
+                  text: "Select the mentors for this claim",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              values: mentorChoices,
+              items: mentorOptions,
+              errorMessage: errors | getErrorMessage("mentorChoices")
+            }) }}
+
+        {% else %}
+
+          {% set headingHtml %}
+            {% include "_includes/page-heading-legend.njk" %}
+          {% endset %}
+
+          {{ govukCheckboxes({
+            name: "mentorChoices[]",
+            fieldset: {
+              legend: {
+                html: headingHtml,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--l"
+              }
+            },
+            hint: {
+              text: "Select all that apply"
+            },
+            values: mentorChoices,
+            items: mentorOptions,
+            errorMessage: errors | getErrorMessage("mentorChoices")
+          }) }}
+
+        {% endif %}
 
         {{ govukButton({
           text: "Continue"


### PR DESCRIPTION
This is changes to the 'mentors' and 'hours' pages within the add claim flow.

* Display a details component explaining why not all mentors might be shown in the list (the list now only displays Mentors who can be claimed against)
* Display an inset text that explains how many hours are left to claim for a mentor and why.
* Add question legends under these components to maintain visual relationship and accessibility of label and inputs.

It does not dynamically store or transmit the number of hours remaining for the mentor for each provider. 