### PR TITLE
363 Link Unique claim ref in claims list: Support UR feedback

### DIFF
--- a/app/views/support/claims/list.njk
+++ b/app/views/support/claims/list.njk
@@ -59,11 +59,8 @@
               <header class="app-claim-card__header">
                 <h3 class="govuk-heading-s govuk-!-width-two-thirds">
                   <a href="{{ actions.view }}/{{ claim.id }}" class="govuk-link govuk-link--no-visited-state">
-                    {{ claim.organisationId | getSchoolName }}
+                    {{ claim.reference }} - {{ claim.organisationId | getSchoolName }}
                   </a>
-                  <span class="app-claim-card__caption">
-                    {{ claim.reference }}
-                  </span>
                 </h3>
                 {{ govukTag({
                   text: claim.status | capitalize,


### PR DESCRIPTION
This ticket adds the reference number at the start of the link on the support user claim list, reflecting feedback from UR. It maintains the school name in the link for context.