### PR TITLE
Show who approved the grant conditions in organisation details

### DIFF
--- a/app/controllers/organisations.js
+++ b/app/controllers/organisations.js
@@ -88,6 +88,7 @@ exports.show_organisation_get = (req, res) => {
     actions: {
       back: `/organisations/${req.params.organisationId}`,
       change: `/organisations/${req.params.organisationId}`,
+      conditions: `/organisations/${req.params.organisationId}/conditions`,
       delete: `/organisations/${req.params.organisationId}/delete`
     }
   })

--- a/app/views/_includes/organisations/grant-conditions.njk
+++ b/app/views/_includes/organisations/grant-conditions.njk
@@ -7,7 +7,7 @@
     rows: [
       {
         key: {
-          text: "Signed by"
+          text: "Agreed by"
         },
         value: {
           text: organisation.conditionsAgreedBy | getUserName
@@ -15,7 +15,7 @@
       },
       {
         key: {
-          text: "Signed on"
+          text: "Agreed on"
         },
         value: {
           text: organisation.conditionsAgreedAt | datetime('dd MMMM yyyy')

--- a/app/views/_includes/organisations/grant-conditions.njk
+++ b/app/views/_includes/organisations/grant-conditions.njk
@@ -35,7 +35,7 @@
     </p>
   {% else %}
     <p class="govuk-body">
-      The school has not agreed to the grant conditions.
+      This school has not agreed to the grant conditions.
     </p>
   {% endif %}
 {% endif %}

--- a/app/views/_includes/organisations/grant-conditions.njk
+++ b/app/views/_includes/organisations/grant-conditions.njk
@@ -1,0 +1,41 @@
+<h2 class="govuk-heading-m govuk-!-margin-top-9">
+  Grant conditions
+</h2>
+
+{% if organisation.conditionsAgreed %}
+  {{ govukSummaryList({
+    rows: [
+      {
+        key: {
+          text: "Signed by"
+        },
+        value: {
+          text: organisation.conditionsAgreedBy | getUserName
+        }
+      },
+      {
+        key: {
+          text: "Signed on"
+        },
+        value: {
+          text: organisation.conditionsAgreedAt | datetime('dd MMMM yyyy')
+        }
+      }
+    ]
+  }) }}
+
+  <p class="govuk-body">
+    <a href="/grant-conditions" class="govuk-link">View grant conditions</a>
+  </p>
+{% else %}
+  {# a bit of a hack to show a different message to support #}
+  {% if actions.conditions | length %}
+    <p class="govuk-body">
+      <a href="{{ actions.conditions }}" class="govuk-link">Review and agree to grant conditions</a>
+    </p>
+  {% else %}
+    <p class="govuk-body">
+      The school has not agreed to the grant conditions.
+    </p>
+  {% endif %}
+{% endif %}

--- a/app/views/_includes/organisations/grant-funding.njk
+++ b/app/views/_includes/organisations/grant-funding.njk
@@ -22,7 +22,3 @@
     }
   ]
 }) }}
-
-<p class="govuk-body">
-  <a href="/grant-conditions" class="govuk-link">View grant conditions</a>
-</p>

--- a/app/views/organisations/show.njk
+++ b/app/views/organisations/show.njk
@@ -20,6 +20,8 @@
 
       {% include "_includes/organisations/details.njk" %}
 
+      {% include "_includes/organisations/grant-conditions.njk" %}
+
       {% include "_includes/organisations/grant-funding.njk" %}
 
       {# {% if organisation.type == "school" %}

--- a/app/views/support/organisations/show.njk
+++ b/app/views/support/organisations/show.njk
@@ -32,6 +32,8 @@
 
       {% include "_includes/organisations/details.njk" %}
 
+      {% include "_includes/organisations/grant-conditions.njk" %}
+
       {% include "_includes/organisations/grant-funding.njk" %}
 
       {# {% if organisation.type == "school" %}


### PR DESCRIPTION
In this PR, we show who approved the grant conditions on the school's 'Organisation details' page and the support equivalent.

If the school has not approved the grant conditions, we show a link to 'Review and approve grant conditions'.

In support, if the school has not approved the grant conditions, we show a message, 'This school has not agreed to the grant conditions.'