### PR TITLE
Remove user's agreement to the grant conditions - support flow

### DIFF
--- a/app/controllers/support/organisations.js
+++ b/app/controllers/support/organisations.js
@@ -125,9 +125,41 @@ exports.show_organisation_get = (req, res) => {
     actions: {
       back: `/support/organisations`,
       change: `/support/organisations/${req.params.organisationId}`,
-      delete: `/support/organisations/${req.params.organisationId}/delete`
+      delete: `/support/organisations/${req.params.organisationId}/delete`,
+      deleteConditionsAgreement: `/support/organisations/${req.params.organisationId}/remove-agreement-grant-conditions`
     }
   })
+}
+
+/// ------------------------------------------------------------------------ ///
+/// REMOVE USER'S AGREEMENT TO GRANT CONDITIONS
+/// ------------------------------------------------------------------------ ///
+
+exports.remove_organisation_agreement_get = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+
+  res.render('../views/support/organisations/remove-agreement-grant-conditions', {
+    organisation,
+    actions: {
+      back: `/support/organisations/${req.params.organisationId}`,
+      cancel: `/support/organisations/${req.params.organisationId}`,
+      save: `/support/organisations/${req.params.organisationId}/remove-agreement-grant-conditions`
+    }
+  })
+}
+
+exports.remove_organisation_agreement_post = (req, res) => {
+
+  organisationModel.updateOne({
+    organisationId: req.params.organisationId,
+    userId: req.session.passport.user.id,
+    organisation: {
+      conditionsAgreed: false
+    }
+  })
+
+  req.flash('success', 'Agreement to grant conditions removed')
+  res.redirect(`/support/organisations/${req.params.organisationId}`)
 }
 
 /// ------------------------------------------------------------------------ ///

--- a/app/models/organisations.js
+++ b/app/models/organisations.js
@@ -79,8 +79,6 @@ exports.updateOne = (params) => {
   if (params.organisationId) {
     organisation = this.findOne({ organisationId: params.organisationId })
 
-    console.log(typeof (params.organisation?.conditionsAgreed) === 'boolean');
-
     if (typeof (params.organisation?.conditionsAgreed) === 'boolean') {
       if (params.organisation.conditionsAgreed) {
         organisation.conditionsAgreed = true

--- a/app/models/organisations.js
+++ b/app/models/organisations.js
@@ -79,10 +79,18 @@ exports.updateOne = (params) => {
   if (params.organisationId) {
     organisation = this.findOne({ organisationId: params.organisationId })
 
-    if (params.organisation.conditionsAgreed) {
-      organisation.conditionsAgreed = true
-      organisation.conditionsAgreedBy = params.userId
-      organisation.conditionsAgreedAt = new Date()
+    console.log(typeof (params.organisation?.conditionsAgreed) === 'boolean');
+
+    if (typeof (params.organisation?.conditionsAgreed) === 'boolean') {
+      if (params.organisation.conditionsAgreed) {
+        organisation.conditionsAgreed = true
+        organisation.conditionsAgreedBy = params.userId
+        organisation.conditionsAgreedAt = new Date()
+      } else {
+        organisation.conditionsAgreed = false
+        delete organisation.conditionsAgreedBy
+        delete organisation.conditionsAgreedAt
+      }
     }
 
     organisation.updatedAt = new Date()

--- a/app/routes.js
+++ b/app/routes.js
@@ -378,6 +378,9 @@ router.get('/support/organisations/remove-all-filters', checkIsAuthenticated, su
 
 router.get('/support/organisations/remove-keyword-search', checkIsAuthenticated, supportOrganisationController.removeKeywordSearch)
 
+router.get('/support/organisations/:organisationId/remove-agreement-grant-conditions', checkIsAuthenticated, supportOrganisationController.remove_organisation_agreement_get)
+router.post('/support/organisations/:organisationId/remove-agreement-grant-conditions', checkIsAuthenticated, supportOrganisationController.remove_organisation_agreement_post)
+
 router.get('/support/organisations/:organisationId', checkIsAuthenticated, supportOrganisationController.show_organisation_get)
 
 router.get('/support/organisations', checkIsAuthenticated, supportOrganisationController.list_organisations_get)

--- a/app/views/_includes/organisations/support/grant-conditions.njk
+++ b/app/views/_includes/organisations/support/grant-conditions.njk
@@ -25,10 +25,10 @@
   }) }}
 
   <p class="govuk-body">
-    <a href="/grant-conditions" class="govuk-link">View grant conditions</a>
+    <a class="govuk-link app-link--destructive" href="{{ actions.deleteConditionsAgreement }}">Remove user’s agreement to the grant conditions</a>
   </p>
 {% else %}
   <p class="govuk-body">
-    <a href="{{ actions.conditions }}" class="govuk-link">Review and agree to grant conditions</a>
+    This school has not agreed to the grant conditions.
   </p>
 {% endif %}

--- a/app/views/support/organisations/remove-agreement-grant-conditions.njk
+++ b/app/views/support/organisations/remove-agreement-grant-conditions.njk
@@ -1,0 +1,44 @@
+{% extends "layouts/main.njk" %}
+
+{% set primaryNavId = "users" %}
+
+{% set title = "Are you sure you want to remove " + organisation.conditionsAgreedBy | getUserName + "’s agreement?" %}
+{% set caption = "Agreement to grant conditions" %}
+
+{% block pageTitle %}
+  {{ "Error: " if errors.length }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/error-summary.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% include "_includes/page-heading.njk" %}
+
+      <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
+
+        {{ govukButton({
+          text: "Remove agreement",
+          classes: "govuk-button--warning"
+        }) }}
+
+      </form>
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
+      </p>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/support/organisations/show.njk
+++ b/app/views/support/organisations/show.njk
@@ -14,6 +14,8 @@
 
 {% block content %}
 
+  {% include "_includes/notification-banner.njk" %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/support/organisations/show.njk
+++ b/app/views/support/organisations/show.njk
@@ -32,7 +32,7 @@
 
       {% include "_includes/organisations/details.njk" %}
 
-      {% include "_includes/organisations/grant-conditions.njk" %}
+      {% include "_includes/organisations/support/grant-conditions.njk" %}
 
       {% include "_includes/organisations/grant-funding.njk" %}
 


### PR DESCRIPTION
Only one user per organisation must accept the grant offer conditions when signing in for the first time.

In cases where an inappropriate person has accepted the conditions, or where they were accepted in error, Support users need to be able to reset the declaration in the support console.

This will either allow the user to review and accept the conditions again or allow another user at the school to review and accept the conditions.