### PR TITLE
State that claim will be shared with the accredited provider

### DIFF
--- a/app/views/claims/confirmation.njk
+++ b/app/views/claims/confirmation.njk
@@ -30,6 +30,10 @@
       <h2 class="govuk-heading-m">What happens next</h2>
 
       <p class="govuk-body">
+        This claim will be shared with {{ claim.providerId | getProviderName }}.
+      </p>
+
+      <p class="govuk-body">
         We will check your claim before processing payment. If we need to contact you for further information, we will use the email you used to access this service.
       </p>
 


### PR DESCRIPTION
On the claim confirmation screen, state that `This claim will be shared with {{ accredited provider }}`.