### PR TITLE
Add accredited provider autocomplete

### DIFF
--- a/app/assets/javascripts/init-autocomplete.js
+++ b/app/assets/javascripts/init-autocomplete.js
@@ -42,7 +42,12 @@ const initAutocomplete = ({ element, input, path, selectNameAndCode, type = null
   const getTemplate = (type, result) => {
     let template = `${result.name}`
     if (type === "provider") {
-      template = `${result.name} (${result.code})`
+      template = `${result.name}`
+      if (result.ukprn) {
+        template += ` (UKPRN: ${result.ukprn})`
+      } else if (result.urn) {
+        template += ` (URN: ${result.urn})`
+      }
     } else if (type === "school") {
       template = `${result.name} (${result.address.town}, ${result.address.postcode})`
     }

--- a/app/controllers/claims.js
+++ b/app/controllers/claims.js
@@ -21,6 +21,7 @@ exports.claim_list = (req, res) => {
   delete req.session.data.mentor
   delete req.session.data.mentorChoices
   delete req.session.data.position
+  delete req.session.data.provider
 
   claims.sort((a, b) => {
     return new Date(b.submittedAt) - new Date(a.submittedAt)

--- a/app/controllers/claims.js
+++ b/app/controllers/claims.js
@@ -5,7 +5,6 @@ const providerModel = require('../models/providers')
 
 const Pagination = require('../helpers/pagination')
 const claimHelper = require('../helpers/claims')
-const fundingHelper = require('../helpers/funding')
 const mentorHelper = require('../helpers/mentors')
 
 /// ------------------------------------------------------------------------ ///

--- a/app/controllers/claims.js
+++ b/app/controllers/claims.js
@@ -121,7 +121,7 @@ exports.new_claim_post = (req, res) => {
       actions: {
         save,
         back,
-        cancel: '/support/organisations'
+        cancel: `/organisations/${req.params.organisationId}/claims`
       },
       errors
     })

--- a/app/views/claims/provider.njk
+++ b/app/views/claims/provider.njk
@@ -2,7 +2,7 @@
 
 {% set primaryNavId = "claims" %}
 
-{% set title = "Accredited provider" %}
+{% set title = "Enter an accredited provider name, UKPRN, URN or postcode" %}
 {% set caption = "Add claim" %}
 
 {% block beforeContent %}
@@ -25,28 +25,25 @@
 
       <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
 
-        {{ govukRadios({
-          name: "claim[providerId]",
-          fieldset: {
-            legend: {
+        <div class="govuk-form-group {{- ' govuk-form-group--error' if (errors | getErrorMessage('provider'))}}">
+          {{ govukInput({
+            id: "provider",
+            name: "provider[name]",
+            label: {
               html: headingHtml,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--l"
-            }
-          },
-          value: claim.providerId,
-          items: [
-            {
-              value: "41164d27-f161-4a0f-b07c-fcf19fe53cc2",
-              text: "Best Practice Network"
+              classes: "govuk-label--l"
             },
-            {
-              value: "15ca4914-3505-41a1-80ea-5a0312c8ead4",
-              text: "NIoT: National Institute of Teaching, founded by the School-Led Development Trust"
-            }
-          ],
-          errorMessage: errors | getErrorMessage("provider")
-        }) }}
+            value: data.provider.name,
+            autocomplete: "off",
+            formGroup: {
+              classes: "govuk-!-margin-bottom-0"
+            },
+            errorMessage: errors | getErrorMessage("provider")
+          }) }}
+          <div id="provider-autocomplete" class="govuk-body"></div>
+        </div>
+
 
         {{ govukButton({
           text: "Continue"
@@ -61,4 +58,19 @@
     </div>
   </div>
 
+{% endblock %}
+
+{% block pageScripts %}
+  <script src="/public/javascripts/accessible-autocomplete.min.js"></script>
+  <script src="/public/javascripts/debounce.js"></script>
+  <script src="/public/javascripts/init-autocomplete.js"></script>
+
+  <script type="text/javascript">
+  initAutocomplete({
+    element: "provider-autocomplete",
+    input: "provider",
+    path: "/provider-suggestions",
+    type: "provider"
+  });
+  </script>
 {% endblock %}


### PR DESCRIPTION
In private beta, the service has two radio buttons for accredited ITT provider selection:

- Best Practice Network
- NIoT: National Institute of Teaching, founded by the School-Led Development Trust

In public beta, users need to be able to choose from all accredited ITT providers. There are too many providers to add to a list of radio options. Elsewhere in BAT, we have used accessible autocomplete, with a no-JavaScript fallback, to allow users to select the appropriate provider.

This PR demonstrates how to use an autocomplete to replace the radio options.

**Enter an accredited provider name, UKPRN, URN or postcode:**

![Screenshot 2024-07-03 at 09 47 24@2x](https://github.com/DFE-Digital/itt-mentoring-beta-prototype/assets/23444/a31d8740-7a4b-4008-b386-acf73eadb51a)

**Error state:**

![Screenshot 2024-07-03 at 09 48 10@2x](https://github.com/DFE-Digital/itt-mentoring-beta-prototype/assets/23444/145158b4-c79f-4937-be81-03b85d30be50)

