### PR TITLE
Link organisation name

### DIFF
--- a/app/controllers/support/claims.js
+++ b/app/controllers/support/claims.js
@@ -219,8 +219,10 @@ exports.show_claim_get = (req, res) => {
   res.render('../views/support/claims/show', {
     organisation,
     claim,
+    showOrganisationLink: true,
     actions: {
-      back: `/support/claims`
+      back: `/support/claims`,
+      organisations: `/support/organisations`
     }
   })
 }

--- a/app/views/_includes/claims/details.njk
+++ b/app/views/_includes/claims/details.njk
@@ -8,6 +8,14 @@
   </ul>
 {% endset %}
 
+{% set organisationNameHtml %}
+  <p class="govuk-body">
+    {% if showOrganisationLink %}<a href="{{ actions.organisations }}/{{ claim.organisationId }}" class="govuk-link">{% endif %}
+      {{- organisation.name if organisation.name else claim.organisationId | getSchoolName -}}
+    {% if showOrganisationLink %}</a>{% endif %}
+  </p>
+{% endset %}
+
 {{ govukSummaryList({
   rows: [
     {
@@ -15,7 +23,7 @@
         text: "School"
       },
       value: {
-        text: organisation.name if organisation.name else claim.organisationId | getSchoolName
+        html: organisationNameHtml
       }
     },
     {


### PR DESCRIPTION
I noticed a mismatch between the live service and the prototype.

The prototype needs a link from the `Support > Claims > Claim details` view to the `Support > Organisations > Organisation details` view.

![Screenshot 2024-07-03 at 09 40 26@2x](https://github.com/DFE-Digital/itt-mentoring-beta-prototype/assets/23444/1b5ba3eb-dddf-4240-a21a-81d66740fbf8)
