### PR TITLE
Fix closing date inset text

### DIFF
--- a/app/views/claims/list.njk
+++ b/app/views/claims/list.njk
@@ -13,8 +13,7 @@
   {% include "_includes/notification-banner.njk" %}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-
+    <div class="govuk-grid-column-two-thirds">
       {% include "_includes/page-heading.njk" %}
 
       {% set insetHtml %}
@@ -27,7 +26,7 @@
             Claims can only be made for the school year September 2023 to July 2024.
           </p>
           <p class="govuk-body">
-            The final date to submit a claim is 19 July 2024.
+            Final closing date for claims: <strong>19 July 2024 at 11.59 pm</strong>
           </p>
         {% endif %}
 
@@ -43,6 +42,11 @@
           href: actions.new
         }) }}
       {% endif %}
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
 
       {% if claims.length %}
         {% include "_includes/claims/list.njk" %}

--- a/app/views/claims/list.njk
+++ b/app/views/claims/list.njk
@@ -26,7 +26,7 @@
             Claims can only be made for the school year September 2023 to July 2024.
           </p>
           <p class="govuk-body">
-            Final closing date for claims: <strong>19 July 2024 at 11:59pm</strong>
+            Final closing date for claims: <strong>19 July 2024 at 11:59 pm</strong>
           </p>
         {% endif %}
 

--- a/app/views/claims/list.njk
+++ b/app/views/claims/list.njk
@@ -26,7 +26,7 @@
             Claims can only be made for the school year September 2023 to July 2024.
           </p>
           <p class="govuk-body">
-            Final closing date for claims: <strong>19 July 2024 at 11.59 pm</strong>
+            Final closing date for claims: <strong>19 July 2024 at 11:59pm</strong>
           </p>
         {% endif %}
 

--- a/app/views/start.njk
+++ b/app/views/start.njk
@@ -23,7 +23,7 @@
       </p>
 
       <p class="govuk-body">
-        Final closing date for claims: <strong>19 July 2024 at 11.59 pm</strong>
+        Final closing date for claims: <strong>19 July 2024 at 11:59pm</strong>
       </p>
 
       <p class="govuk-body">

--- a/app/views/start.njk
+++ b/app/views/start.njk
@@ -23,7 +23,7 @@
       </p>
 
       <p class="govuk-body">
-        Final closing date for claims: <strong>19 July 2024 at 11:59pm</strong>
+        Final closing date for claims: <strong>19 July 2024 at 11:59 pm</strong>
       </p>
 
       <p class="govuk-body">

--- a/app/views/start.njk
+++ b/app/views/start.njk
@@ -23,7 +23,7 @@
       </p>
 
       <p class="govuk-body">
-        Final closing date for claims: <strong>19 July 2024 by 11.59 pm</strong>
+        Final closing date for claims: <strong>19 July 2024 at 11.59 pm</strong>
       </p>
 
       <p class="govuk-body">

--- a/app/views/support/organisations/claims/list.njk
+++ b/app/views/support/organisations/claims/list.njk
@@ -29,23 +29,32 @@
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-two-thirds">
 
       <h2 class="govuk-heading-m">Claims</h2>
 
       {% if not mentors.length %}
-        {% set mentorHtml %}
+        {% set insetHtml %}
           <p class="govuk-body">
-            You need to <a href="{{ actions.mentors }}" class="govuk-link">add a mentor</a> before creating a claim.
+            Before you can start a claim you will need to <a href="{{ actions.mentors }}" class="govuk-link">add a mentor</a>.
           </p>
         {% endset %}
 
         {{ govukInsetText({
-          html: mentorHtml
+          html: insetHtml
         }) }}
       {% else %}
+        {% set insetHtml %}
+          <p class="govuk-body">
+            Claims can only be made for the school year September 2023 to July 2024.
+          </p>
+          <p class="govuk-body">
+            Final closing date for claims: <strong>19 July 2024 at 11.59 pm</strong>
+          </p>
+        {% endset %}
+
         {{ govukInsetText({
-          text: "You can only claim for the academic year September 2023 to July 2024."
+          html: insetHtml
         }) }}
 
         {{ govukButton({
@@ -53,6 +62,12 @@
           href: actions.new
         }) }}
       {% endif %}
+
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
 
       {% if claims.length %}
         {% include "_includes/claims/list.njk" %}

--- a/app/views/support/organisations/claims/list.njk
+++ b/app/views/support/organisations/claims/list.njk
@@ -49,7 +49,7 @@
             Claims can only be made for the school year September 2023 to July 2024.
           </p>
           <p class="govuk-body">
-            Final closing date for claims: <strong>19 July 2024 at 11:59pm</strong>
+            Final closing date for claims: <strong>19 July 2024 at 11:59 pm</strong>
           </p>
         {% endset %}
 

--- a/app/views/support/organisations/claims/list.njk
+++ b/app/views/support/organisations/claims/list.njk
@@ -49,7 +49,7 @@
             Claims can only be made for the school year September 2023 to July 2024.
           </p>
           <p class="govuk-body">
-            Final closing date for claims: <strong>19 July 2024 at 11.59 pm</strong>
+            Final closing date for claims: <strong>19 July 2024 at 11:59pm</strong>
           </p>
         {% endset %}
 


### PR DESCRIPTION
I noticed differences between the school and support-facing inset text on the claims lists.

This PR copies the school-facing text to the support service and updates the date format.

The PR also fixes the date format: `19 July 2024 at 11:59 pm`:
- use "at" instead of "by"
- use colon between hours and minutes