### PR TITLE
Add prototype settings

### DIFF
--- a/app/controllers/authentication.js
+++ b/app/controllers/authentication.js
@@ -1,4 +1,4 @@
-const settings = require('../data/settings')
+const settings = require('../data/dist/settings')
 
 exports.sign_in_get = (req, res) => {
   if (req.session.passport) {
@@ -6,7 +6,7 @@ exports.sign_in_get = (req, res) => {
   } else {
     const errors = req.flash()
     res.render('../views/auth/index', {
-      useLogin: process.env.USE_LOGIN || settings.useLogin,
+      useLogin: settings.useLogin || process.env.USE_LOGIN,
       actions: {
         save: '/sign-in',
         create: '/register',

--- a/app/controllers/claims.js
+++ b/app/controllers/claims.js
@@ -7,6 +7,8 @@ const Pagination = require('../helpers/pagination')
 const claimHelper = require('../helpers/claims')
 const mentorHelper = require('../helpers/mentors')
 
+const settings = require('../data/dist/settings')
+
 /// ------------------------------------------------------------------------ ///
 /// LIST CLAIM
 /// ------------------------------------------------------------------------ ///
@@ -28,9 +30,7 @@ exports.claim_list = (req, res) => {
       || new Date(b.createdAt) - new Date(a.createdAt)
   })
 
-  // TODO: get pageSize from settings
-  let pageSize = 25
-  let pagination = new Pagination(claims, req.query.page, pageSize)
+  const pagination = new Pagination(claims, req.query.page, settings.pageSize)
   claims = pagination.getData()
 
   res.render('../views/claims/list', {

--- a/app/controllers/mentors.js
+++ b/app/controllers/mentors.js
@@ -8,6 +8,8 @@ const arrayHelper = require('../helpers/arrays')
 const dateHelper = require('../helpers/dates')
 const validationHelper = require('../helpers/validators')
 
+const settings = require('../data/dist/settings')
+
 /// ------------------------------------------------------------------------ ///
 /// SHOW MENTOR
 /// ------------------------------------------------------------------------ ///
@@ -20,9 +22,7 @@ exports.mentor_list = (req, res) => {
     return a.firstName.localeCompare(b.firstName) || a.lastName.localeCompare(b.lastName)
   })
 
-  // TODO: get pageSize from settings
-  let pageSize = 25
-  let pagination = new Pagination(mentors, req.query.page, pageSize)
+  const pagination = new Pagination(mentors, req.query.page, settings.pageSize)
   mentors = pagination.getData()
 
   delete req.session.data.mentor

--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -1,0 +1,35 @@
+const settingModel = require('../models/settings')
+
+exports.settings_form_get = (req, res) => {
+  const settings = require('../data/dist/settings.json')
+
+  res.render('../views/settings/index', {
+    settings,
+    actions: {
+      save: `/settings`,
+      home: '/organisations'
+    }
+  })
+}
+
+exports.settings_form_post = (req, res) => {
+  const errors = []
+
+  settingModel.update({
+    settings: req.session.data.settings
+  })
+
+  if (errors.length) {
+    res.render('../views/settings/index', {
+      wordCount,
+      actions: {
+        save: `/settings`,
+        home: '/organisations'
+      },
+      errors
+    })
+  } else {
+    req.flash('success', 'Settings updated')
+    res.redirect('/settings')
+  }
+}

--- a/app/controllers/support/claims.js
+++ b/app/controllers/support/claims.js
@@ -10,6 +10,8 @@ const statusHelper = require('../../helpers/statuses')
 
 const claimDecorator = require('../../decorators/claims')
 
+const settings = require('../../data/dist/settings')
+
 /// ------------------------------------------------------------------------ ///
 /// LIST CLAIMS
 /// ------------------------------------------------------------------------ ///
@@ -141,8 +143,7 @@ exports.list_claims_get = (req, res) => {
   //   return a.name.localeCompare(b.name) || a.type.localeCompare(b.type)
   // })
 
-  let pageSize = 25
-  let pagination = new Pagination(claims, req.query.page, pageSize)
+  const pagination = new Pagination(claims, req.query.page, settings.pageSize)
   claims = pagination.getData()
 
   res.render('../views/support/claims/list', {

--- a/app/controllers/support/organisations.js
+++ b/app/controllers/support/organisations.js
@@ -6,6 +6,8 @@ const schoolModel = require('../../models/schools')
 const Pagination = require('../../helpers/pagination')
 const utilsHelper = require('../../helpers/utils')
 
+const settings = require('../../data/dist/settings')
+
 exports.list_organisations_get = (req, res) => {
   // Clean out data from add organisation flow if present
   delete req.session.data.organisation
@@ -66,9 +68,7 @@ exports.list_organisations_get = (req, res) => {
     return a.name.localeCompare(b.name) || a.type.localeCompare(b.type)
   })
 
-
-  let pageSize = 25
-  let pagination = new Pagination(organisations, req.query.page, pageSize)
+  const pagination = new Pagination(organisations, req.query.page, settings.pageSize)
   organisations = pagination.getData()
 
   res.render('../views/support/organisations/list', {

--- a/app/controllers/support/organisations/claims.js
+++ b/app/controllers/support/organisations/claims.js
@@ -8,6 +8,8 @@ const claimHelper = require('../../../helpers/claims')
 const fundingHelper = require('../../../helpers/funding')
 const mentorHelper = require('../../../helpers/mentors')
 
+const settings = require('../../../data/dist/settings')
+
 /// ------------------------------------------------------------------------ ///
 /// LIST CLAIM
 /// ------------------------------------------------------------------------ ///
@@ -28,9 +30,7 @@ exports.claim_list = (req, res) => {
       || new Date(b.createdAt) - new Date(a.createdAt)
   })
 
-  // TODO: get pageSize from settings
-  let pageSize = 25
-  let pagination = new Pagination(claims, req.query.page, pageSize)
+  const pagination = new Pagination(claims, req.query.page, settings.pageSize)
   claims = pagination.getData()
 
   res.render('../views/support/organisations/claims/list', {

--- a/app/controllers/support/organisations/mentors.js
+++ b/app/controllers/support/organisations/mentors.js
@@ -7,6 +7,8 @@ const arrayHelper = require('../../../helpers/arrays')
 const dateHelper = require('../../../helpers/dates')
 const validationHelper = require('../../../helpers/validators')
 
+const settings = require('../../../data/dist/settings')
+
 /// ------------------------------------------------------------------------ ///
 /// LIST MENTOR
 /// ------------------------------------------------------------------------ ///
@@ -19,9 +21,7 @@ exports.mentor_list = (req, res) => {
     return a.firstName.localeCompare(b.firstName) || a.lastName.localeCompare(b.lastName)
   })
 
-  // TODO: get pageSize from settings
-  let pageSize = 25
-  let pagination = new Pagination(mentors, req.query.page, pageSize)
+  const pagination = new Pagination(mentors, req.query.page, settings.pageSize)
   mentors = pagination.getData()
 
   delete req.session.data.mentor

--- a/app/controllers/support/organisations/users.js
+++ b/app/controllers/support/organisations/users.js
@@ -4,6 +4,8 @@ const organisationModel = require('../../../models/organisations')
 const Pagination = require('../../../helpers/pagination')
 const validationHelper = require('../../../helpers/validators')
 
+const settings = require('../../../data/dist/settings')
+
 /// ------------------------------------------------------------------------ ///
 /// SHOW USER
 /// ------------------------------------------------------------------------ ///
@@ -16,9 +18,7 @@ exports.user_list = (req, res) => {
     return a.firstName.localeCompare(b.firstName) || a.lastName.localeCompare(b.lastName)
   })
 
-  // TODO: get pageSize from settings
-  let pageSize = 25
-  let pagination = new Pagination(users, req.query.page, pageSize)
+  const pagination = new Pagination(users, req.query.page, settings.pageSize)
   users = pagination.getData()
 
   delete req.session.data.user

--- a/app/controllers/support/users.js
+++ b/app/controllers/support/users.js
@@ -3,6 +3,8 @@ const userModel = require('../../models/support-users')
 const Pagination = require('../../helpers/pagination')
 const validationHelper = require('../../helpers/validators')
 
+const settings = require('../../data/dist/settings')
+
 /// ------------------------------------------------------------------------ ///
 /// LIST USERS
 /// ------------------------------------------------------------------------ ///
@@ -14,9 +16,7 @@ exports.user_list = (req, res) => {
     return a.firstName.localeCompare(b.firstName) || a.lastName.localeCompare(b.lastName)
   })
 
-  // TODO: get pageSize from settings
-  let pageSize = 25
-  let pagination = new Pagination(users, req.query.page, pageSize)
+  const pagination = new Pagination(users, req.query.page, settings.pageSize)
   users = pagination.getData()
 
   delete req.session.data.user

--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -4,6 +4,8 @@ const organisationModel = require('../models/organisations')
 const Pagination = require('../helpers/pagination')
 const validationHelper = require('../helpers/validators')
 
+const settings = require('../data/dist/settings')
+
 /// ------------------------------------------------------------------------ ///
 /// SHOW USER
 /// ------------------------------------------------------------------------ ///
@@ -16,9 +18,7 @@ exports.user_list = (req, res) => {
     return a.firstName.localeCompare(b.firstName) || a.lastName.localeCompare(b.lastName)
   })
 
-  // TODO: get pageSize from settings
-  let pageSize = 25
-  let pagination = new Pagination(users, req.query.page, pageSize)
+  const pagination = new Pagination(users, req.query.page, settings.pageSize)
   users = pagination.getData()
 
   delete req.session.data.user

--- a/app/data/seed/settings.json
+++ b/app/data/seed/settings.json
@@ -1,0 +1,5 @@
+{
+  "useLogin": "false",
+  "showStartPage": "false",
+  "pageSize": 25
+}

--- a/app/data/settings.json
+++ b/app/data/settings.json
@@ -1,4 +1,0 @@
-{
-  "useLogin": "false",
-  "useLoginFallback": "false"
-}

--- a/app/models/settings.js
+++ b/app/models/settings.js
@@ -1,0 +1,30 @@
+const path = require('path')
+const fs = require('fs')
+
+const directoryPath = path.join(__dirname, '../data/dist/')
+
+exports.update = (params) => {
+  let settings = require('../data/dist/settings')
+
+  if (params.settings.useLogin) {
+    settings.useLogin = params.settings.useLogin
+  }
+
+  if (params.settings.showStartPage) {
+    settings.showStartPage = params.settings.showStartPage
+  }
+
+  if (params.settings.pageSize) {
+    settings.pageSize = params.settings.pageSize
+  }
+
+  const filePath = directoryPath + '/settings.json'
+
+  // create a JSON sting for the submitted data
+  const fileData = JSON.stringify(settings)
+
+  // write the JSON data
+  fs.writeFileSync(filePath, fileData)
+
+  return settings
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -6,7 +6,7 @@
 const govukPrototypeKit = require('govuk-prototype-kit')
 const router = govukPrototypeKit.requests.setupRouter()
 
-const settings = require('./data/settings')
+const settings = require('./data/dist/settings')
 
 /// ------------------------------------------------------------------------ ///
 /// Flash messaging
@@ -54,6 +54,7 @@ const errorController = require('./controllers/errors')
 const feedbackController = require('./controllers/feedback')
 const mentorController = require('./controllers/mentors')
 const organisationController = require('./controllers/organisations')
+const settingController = require('./controllers/settings')
 const userController = require('./controllers/users')
 
 const supportOrganisationController = require('./controllers/support/organisations')
@@ -88,15 +89,19 @@ const checkIsAuthenticated = (req, res, next) => {
 /// ------------------------------------------------------------------------ ///
 
 router.all('*', (req, res, next) => {
-  res.locals.settings = settings
   res.locals.referrer = req.query.referrer
   res.locals.query = req.query
   res.locals.flash = req.flash('success') // pass through 'success' messages only
+
+  for (let settingName of Object.keys(settings)) {
+    res.locals[settingName] = settings[settingName]
+  }
+
   next()
 })
 
 router.get('/', (req, res) => {
-  if (process.env.SHOW_START_PAGE === 'true') {
+  if (settings.showStartPage === 'true' || process.env.SHOW_START_PAGE === 'true') {
     res.render('start')
   } else {
     res.redirect('/sign-in')
@@ -390,6 +395,9 @@ router.get('/support/organisations', checkIsAuthenticated, supportOrganisationCo
 /// ------------------------------------------------------------------------ ///
 /// GENERAL ROUTES
 /// ------------------------------------------------------------------------ ///
+
+router.get('/settings', settingController.settings_form_get)
+router.post('/settings', settingController.settings_form_post)
 
 router.get('/feedback', feedbackController.feedback_form_get)
 router.post('/feedback', feedbackController.feedback_form_post)

--- a/app/views/_includes/footer.njk
+++ b/app/views/_includes/footer.njk
@@ -47,6 +47,9 @@
     }, {
       href: "/manage-prototype/clear-data",
       text: "Clear data"
+    }, {
+      href: "/settings",
+      text: "Settings"
     }] if not hideFooterLinks
   }
 }) }}

--- a/app/views/settings/index.njk
+++ b/app/views/settings/index.njk
@@ -1,0 +1,99 @@
+{% extends "layouts/auth.njk" %}
+
+{% set headerNavId = "settings" %}
+
+{% set hidePrimaryNavigation = true %}
+{% set hideOrganisationSwitcher = true %}
+
+{% set title = "Prototype settings" %}
+
+{% block beforeContent %}
+{{ govukBreadcrumbs({
+  items: [{
+    text: "Home",
+    href: "/"
+  }, {
+    text: title
+  }]
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/notification-banner.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% include "_includes/page-heading.njk" %}
+
+      <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
+
+        {{ govukRadios({
+          name: "settings[useLogin]",
+          fieldset: {
+            legend: {
+              text: "Use pseudo DfE Sign-in",
+              isPageHeading: false,
+              classes: "govuk-fieldset__legend--s"
+            }
+          },
+          value: settings.useLogin,
+          items: [
+            {
+              value: "true",
+              text: "Yes"
+            },
+            {
+              value: "false",
+              text: "No"
+            }
+          ],
+          classes: "govuk-radios--inline"
+        }) }}
+
+        {{ govukRadios({
+          name: "settings[showStartPage]",
+          fieldset: {
+            legend: {
+              text: "Show start page",
+              isPageHeading: false,
+              classes: "govuk-fieldset__legend--s"
+            }
+          },
+          value: settings.showStartPage,
+          items: [
+            {
+              value: "true",
+              text: "Yes"
+            },
+            {
+              value: "false",
+              text: "No"
+            }
+          ],
+          classes: "govuk-radios--inline"
+        }) }}
+
+        {{ govukInput({
+          id: "settings-pagesize",
+          name: "settings[pageSize]",
+          label: {
+            text: "Number of items per page for pagination",
+            isPageHeading: false,
+            classes: "govuk-label--s"
+          },
+          value: settings.pageSize,
+          classes: "govuk-input--width-2"
+        }) }}
+
+        {{ govukButton({
+          text: "Save settings"
+        }) }}
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
This PR tests out an idea to add configurable settings to prototypes.

A similar approach can/will be used in other BAT prototypes.

Settings can be accessed via a link in the prototype's footer.