### PR TITLE
Add an admin section to allow someone to reset the prototype data

### DIFF
--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -33,3 +33,18 @@ exports.settings_form_post = (req, res) => {
     res.redirect('/settings')
   }
 }
+
+exports.reset_data_get = (req, res) => {
+  res.render('../views/settings/data', {
+    actions: {
+      save: `/settings/reset-data`,
+      home: '/organisations'
+    }
+  })
+}
+
+exports.reset_data_post = (req, res) => {
+  delete req.session.data
+  settingModel.reset()
+  res.redirect('/sign-out')
+}

--- a/app/models/settings.js
+++ b/app/models/settings.js
@@ -1,5 +1,6 @@
-const path = require('path')
 const fs = require('fs')
+const path = require('path')
+const { rimrafSync } = require('rimraf')
 
 const directoryPath = path.join(__dirname, '../data/dist/')
 
@@ -31,4 +32,53 @@ exports.update = (params) => {
   fs.writeFileSync(filePath, fileData)
 
   return settings
+}
+
+exports.reset = () => {
+  const sourceDirectory = path.join(__dirname, '../data/seed')
+  const destinationDirectory = path.join(__dirname, '../data/dist')
+
+  const copy = (source, destination) => {
+    if (!fs.existsSync(destinationDirectory)) {
+      console.log('Creating directory: ' + destinationDirectory)
+      fs.mkdirSync(destinationDirectory)
+    }
+
+    const list = fs.readdirSync(source)
+    let sourceFile, destinationFile
+
+    list.forEach((file) => {
+      sourceFile = source + '/' + file
+      destinationFile = destination + '/' + file
+
+      const stat = fs.statSync(sourceFile)
+      if (stat && stat.isDirectory()) {
+        try {
+          console.log('Creating directory: ' + destinationFile)
+          fs.mkdirSync(destinationFile)
+        } catch (e) {
+          console.log('Directory already exists: ' + destinationFile)
+        }
+        copy(sourceFile, destinationFile)
+      } else {
+        try {
+          if (!destinationFile.includes('.gitkeep') && !destinationFile.includes('README.md')) {
+            console.log('Copying file: ' + destinationFile)
+            fs.writeFileSync(destinationFile, fs.readFileSync(sourceFile))
+          }
+        } catch (e) {
+          console.log('Could’t copy file: ' + destinationFile)
+        }
+      }
+    })
+  }
+
+  const remove = (destination) => {
+    console.log('Removing directory: ' + destination)
+    rimrafSync(destination)
+  }
+
+  remove(destinationDirectory)
+
+  copy(sourceDirectory, destinationDirectory)
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -415,6 +415,9 @@ router.get('/support/organisations', checkIsAuthenticated, supportOrganisationCo
 router.get('/settings', settingController.settings_form_get)
 router.post('/settings', settingController.settings_form_post)
 
+router.get('/settings/reset-data', settingController.reset_data_get)
+router.post('/settings/reset-data', settingController.reset_data_post)
+
 router.get('/feedback', feedbackController.feedback_form_get)
 router.post('/feedback', feedbackController.feedback_form_post)
 

--- a/app/views/_includes/footer.njk
+++ b/app/views/_includes/footer.njk
@@ -45,16 +45,11 @@
       href: "/terms",
       text: "Terms and conditions"
     }, {
-      href: "/manage-prototype/clear-data",
-      text: "Clear data"
+      href: "/settings/reset-data",
+      text: "Reset data"
     }, {
       href: "/settings",
       text: "Settings"
     }] if not hideFooterLinks
   }
 }) }}
-
-{# , {
-  href: "/prototype-admin/clear-data",
-  text: "Clear data"
-} #}

--- a/app/views/settings/data.njk
+++ b/app/views/settings/data.njk
@@ -1,0 +1,44 @@
+{% extends "layouts/auth.njk" %}
+
+{% set headerNavId = "settings" %}
+
+{% set hidePrimaryNavigation = true %}
+{% set hideOrganisationSwitcher = true %}
+
+{% set title = "Reset prototype data" %}
+
+{% block beforeContent %}
+{{ govukBreadcrumbs({
+  items: [{
+    text: "Home",
+    href: "/"
+  }, {
+    text: title
+  }]
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/notification-banner.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% include "_includes/page-heading.njk" %}
+
+      <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
+
+        <p class="govuk-body">Selecting ‘{{ title }}’ will rebuild the prototype database. This action cannot be undone.</p>
+
+        {{ govukButton({
+          text: title,
+          classes: "govuk-button--warning"
+        }) }}
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
This PR adds a way to reset the prototype data without using the command line. It includes:

- rebuilding the prototype data `dist` directory
- clearing the session data 

The feature is available via the `Reset data` footer menu item.

