### PR TITLE
Remove red links and reposition them

### DIFF
--- a/app/views/_includes/organisations/support/grant-conditions.njk
+++ b/app/views/_includes/organisations/support/grant-conditions.njk
@@ -25,7 +25,7 @@
   }) }}
 
   <p class="govuk-body">
-    <a class="govuk-link app-link--destructive" href="{{ actions.deleteConditionsAgreement }}">Remove user’s agreement to the grant conditions</a>
+    <a class="govuk-link" href="{{ actions.deleteConditionsAgreement }}">Remove user’s agreement to the grant conditions</a>
   </p>
 {% else %}
   <p class="govuk-body">

--- a/app/views/claims/show.njk
+++ b/app/views/claims/show.njk
@@ -31,11 +31,19 @@
       {% include "_includes/page-heading.njk" %}
 
       {% if claim.academicYear | isCurrentAcademicYear and claim.status == "draft" %}
-        {{ govukButton({
-          text: "Submit claim",
-          href: actions.submit
-        }) }}
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Submit claim",
+            href: actions.submit
+          }) }}
+          <a class="govuk-link" href="{{ actions.delete }}">Remove claim</a>
+        </div>
       {% else %}
+        {% if claim.status == "draft" %}
+          <p class="govuk-body">
+            <a class="govuk-link" href="{{ actions.delete }}">Remove claim</a>
+          </p>
+        {% endif %}
         {% include "_includes/claims/meta-data.njk" %}
       {% endif %}
 
@@ -47,12 +55,6 @@
 
       {% if claim.status in ["clawback_complete","clawback_requested","clawback_in_progress"] %}
         {% include "_includes/claims/clawback-details.njk" %}
-      {% endif %}
-
-      {% if claim.status == "draft" %}
-        <p class="govuk-body">
-          <a class="govuk-link app-link--destructive" href="{{ actions.delete }}">Remove claim</a>
-        </p>
       {% endif %}
 
     </div>

--- a/app/views/mentors/show.njk
+++ b/app/views/mentors/show.njk
@@ -20,11 +20,11 @@
 
       {% include "_includes/page-heading.njk" %}
 
-      {% include "_includes/mentors/details.njk" %}
-
       <p class="govuk-body">
-        <a class="govuk-link app-link--destructive" href="{{ actions.delete }}">Remove mentor</a>
+        <a class="govuk-link" href="{{ actions.delete }}">Remove mentor</a>
       </p>
+
+      {% include "_includes/mentors/details.njk" %}
 
     </div>
   </div>

--- a/app/views/support/organisations/claims/show.njk
+++ b/app/views/support/organisations/claims/show.njk
@@ -32,6 +32,12 @@
 
       {% include "_includes/page-heading.njk" %}
 
+      {% if claim.status == "draft" %}
+        <p class="govuk-body">
+          <a class="govuk-link" href="{{ actions.delete }}">Remove claim</a>
+        </p>
+      {% endif %}
+
       {% include "_includes/claims/meta-data.njk" %}
 
       {% include "_includes/claims/details.njk" %}
@@ -39,12 +45,6 @@
       {% include "_includes/claims/hours-of-training.njk" %}
 
       {% include "_includes/claims/grant-funding.njk" %}
-
-      {% if claim.status == "draft" %}
-        <p class="govuk-body">
-          <a class="govuk-link app-link--destructive" href="{{ actions.delete }}">Remove claim</a>
-        </p>
-      {% endif %}
 
     </div>
   </div>

--- a/app/views/support/organisations/mentors/show.njk
+++ b/app/views/support/organisations/mentors/show.njk
@@ -21,11 +21,12 @@
 
       {% include "_includes/page-heading.njk" %}
 
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ actions.delete }}">Remove mentor</a>
+      </p>
+
       {% include "_includes/mentors/details.njk" %}
 
-      <p class="govuk-body">
-        <a class="govuk-link app-link--destructive" href="{{ actions.delete }}">Remove mentor</a>
-      </p>
 
     </div>
   </div>

--- a/app/views/support/organisations/show.njk
+++ b/app/views/support/organisations/show.njk
@@ -20,6 +20,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       {% include "_includes/page-heading.njk" %}
+
     </div>
   </div>
 
@@ -31,6 +32,10 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ actions.delete }}">Remove organisation</a>
+      </p>
 
       {% include "_includes/organisations/support/details.njk" %}
 
@@ -49,10 +54,6 @@
       {% endif %} #}
 
       {% include "_includes/organisations/contact-details.njk" %}
-
-      <p class="govuk-body">
-        <a class="govuk-link app-link--destructive" href="{{ actions.delete }}">Remove organisation</a>
-      </p>
 
     </div>
   </div>

--- a/app/views/support/organisations/users/show.njk
+++ b/app/views/support/organisations/users/show.njk
@@ -21,13 +21,13 @@
 
       {% include "_includes/page-heading.njk" %}
 
-      {% include "_includes/users/details.njk" %}
-
       {% if not (user.id == signedInUser.id) %}
         <p class="govuk-body">
-          <a class="govuk-link app-link--destructive" href="{{ actions.delete }}">Remove user</a>
+          <a class="govuk-link" href="{{ actions.delete }}">Remove user</a>
         </p>
       {% endif %}
+
+      {% include "_includes/users/details.njk" %}
 
     </div>
   </div>

--- a/app/views/support/settings/windows/show.njk
+++ b/app/views/support/settings/windows/show.njk
@@ -21,6 +21,10 @@
 
       {% include "_includes/page-heading.njk" %}
 
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ actions.delete }}">Remove claim window</a>
+      </p>
+
       {{ govukSummaryList({
         rows: [
           {
@@ -76,10 +80,6 @@
           }
         ]
       }) }}
-
-      <p class="govuk-body">
-        <a class="govuk-link app-link--destructive" href="{{ actions.delete }}">Remove claim window</a>
-      </p>
 
     </div>
   </div>

--- a/app/views/support/users/show.njk
+++ b/app/views/support/users/show.njk
@@ -20,13 +20,13 @@
 
       {% include "_includes/page-heading.njk" %}
 
-      {% include "_includes/users/details.njk" %}
-
       {% if not (user.id == signedInUser.id) %}
         <p class="govuk-body">
-          <a class="govuk-link app-link--destructive" href="{{ actions.delete }}">Remove user</a>
+          <a class="govuk-link" href="{{ actions.delete }}">Remove user</a>
         </p>
       {% endif %}
+
+      {% include "_includes/users/details.njk" %}
 
     </div>
   </div>

--- a/app/views/users/show.njk
+++ b/app/views/users/show.njk
@@ -20,13 +20,13 @@
 
       {% include "_includes/page-heading.njk" %}
 
-      {% include "_includes/users/details.njk" %}
-
       {% if not (user.id == signedInUser.id) %}
         <p class="govuk-body">
-          <a class="govuk-link app-link--destructive" href="{{ actions.delete }}">Remove user</a>
+          <a class="govuk-link" href="{{ actions.delete }}">Remove user</a>
         </p>
       {% endif %}
+
+      {% include "_includes/users/details.njk" %}
 
     </div>
   </div>


### PR DESCRIPTION
We use a service-specific class to indicate destructive links, which makes them red. This is simply a style choice. The colour doesn't prevent colour-blind users from understanding the link's meaning.

Examples of services that use this pattern:

- Publish teacher training courses
- Register trainee teachers
- GOV.UK Notify
- GOV.UK Pay
- GOV.UK Content Publisher - mothballed

Despite these precedents and following design feedback from the department, this PR removes the `app-link--destructive` class from all 'remove' links. We have also repositioned the links below the page heading to correspond to the position of other actions.

Pages changed:

- Schools
  - Claim details
  - Mentor details
  - User details
- Support
  - Support user details
  - Organisations
    - Details - remove organisation and remove grant conditions approval
    - Claim details
    - Mentor details
    - User details