### PR TITLE
Fix support organisation details inconsistency

### DIFF
--- a/app/views/support/organisations/_secondary-navigation.njk
+++ b/app/views/support/organisations/_secondary-navigation.njk
@@ -3,7 +3,7 @@
   items: [
     {
       href: baseUrl,
-      text: "Details",
+      text: "Organisation details",
       active: secondaryNavId == "details"
     },
     {

--- a/app/views/support/organisations/show.njk
+++ b/app/views/support/organisations/show.njk
@@ -32,6 +32,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+      <h2 class="govuk-heading-m">Organisation details</h2>
+
       {% include "_includes/organisations/support/details.njk" %}
 
       {% include "_includes/organisations/support/grant-conditions.njk" %}


### PR DESCRIPTION
The organisation details section is inconsistent; it is called “Details” and has no subtitle. 

This PR proposes we:

- change the secondary navigation to “Organisation details” since this is what we call it on the school-facing side
- add a subtitle, “Organisation details”, since this is what we do for users, mentors and claims sections to orientate users

Example:

https://github.com/user-attachments/assets/305808f6-ee88-42a6-994f-4c54ee201a9c


