### PR TITLE
Use GOV.UK Design System's service navigation component

### DIFF
--- a/app/views/_components/secondary-navigation/_secondary-navigation.scss
+++ b/app/views/_components/secondary-navigation/_secondary-navigation.scss
@@ -41,7 +41,7 @@
   padding-left: govuk-spacing(3);
   text-decoration: none;
   position: relative;
-  font-weight: bold;
+  // font-weight: bold;
 
   @include govuk-media-query($from: tablet) {
     padding-left: 0;

--- a/app/views/layouts/main.njk
+++ b/app/views/layouts/main.njk
@@ -2,7 +2,6 @@
 
 {% from "_components/footer/macro.njk" import appFooter %}
 {% from "_components/organisation-actions/macro.njk" import appOrganisationActions %}
-{% from "_components/primary-navigation/macro.njk" import appPrimaryNavigation %}
 
 {% block pageTitle %}
   {{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
@@ -60,8 +59,8 @@
   {% endif %}
 
   {% if not hidePrimaryNavigation %}
-    {{ appPrimaryNavigation({
-      items: [
+    {{ govukServiceNavigation({
+      navigation: [
         {
           href: baseUrl + "/claims",
           text: "Claims",

--- a/app/views/layouts/support.njk
+++ b/app/views/layouts/support.njk
@@ -3,7 +3,6 @@
 {% from "_components/checkbox-filter/macro.njk" import appCheckboxFilter %}
 {% from "_components/footer/macro.njk" import appFooter %}
 {% from "_components/organisation-actions/macro.njk" import appOrganisationActions %}
-{% from "_components/primary-navigation/macro.njk" import appPrimaryNavigation %}
 {% from "_components/search/macro.njk" import appSearch %}
 {% from "_components/secondary-navigation/macro.njk" import appSecondaryNavigation %}
 {% from "_components/timeline/macro.njk" import appTimeline %}
@@ -44,8 +43,8 @@
   }) }}
 
   {% if not hidePrimaryNavigation %}
-    {{ appPrimaryNavigation({
-      items: [
+    {{ govukServiceNavigation({
+      navigation: [
         {
           href: "/support/organisations",
           text: "Organisations",

--- a/app/views/support/claims/_secondary-navigation.njk
+++ b/app/views/support/claims/_secondary-navigation.njk
@@ -1,5 +1,5 @@
 {{ appSecondaryNavigation({
-  label: "Sub navigation",
+  label: "Claims navigation",
   items: [
     {
       href: "/support/claims",

--- a/app/views/support/organisations/_secondary-navigation.njk
+++ b/app/views/support/organisations/_secondary-navigation.njk
@@ -1,5 +1,5 @@
 {{ appSecondaryNavigation({
-  label: "Sub navigation",
+  label: "Organisation navigation",
   items: [
     {
       href: baseUrl,
@@ -16,16 +16,6 @@
       text: "Mentors",
       active: secondaryNavId == "mentors"
     } if organisation.type == "school",
-    {
-      href: "#",
-      text: "Providers",
-      active: secondaryNavId == "providers"
-    } if organisation.type == "school" and 1==0,
-    {
-      href: "#",
-      text: "Schools",
-      active: secondaryNavId == "schools"
-    } if organisation.type != "school" and 1==0,
     {
       href: baseUrl + "/claims",
       text: "Claims",


### PR DESCRIPTION
This PR removes the custom "Primary navigation" component and replaces ith with the GOV.UK Design System's [service navigation component](https://design-system.service.gov.uk/components/service-navigation/).