### PR TITLE
Fix the sampling provider response process

### DIFF
--- a/app/controllers/support/sampling.js
+++ b/app/controllers/support/sampling.js
@@ -622,8 +622,8 @@ exports.review_response_claims_post = (req, res) => {
     const hasUnapprovedMentor = unapprovedMentors.length > 0
 
     const unapprovedReasons = hasUnapprovedMentor
-      ? unapprovedMentors.map(mentor => mentor.claim_not_assured_reason).join('; ')
-      : null
+    ? unapprovedMentors.map(mentor => `${mentor.mentor_full_name}: ${mentor.claim_not_assured_reason}`).join('; ')
+    : null
 
     const claimStatus = hasUnapprovedMentor ? 'sampling_provider_not_approved' : 'paid'
 

--- a/app/controllers/support/sampling.js
+++ b/app/controllers/support/sampling.js
@@ -616,7 +616,7 @@ exports.review_response_claims_post = (req, res) => {
 
   claims.forEach(claim => {
     const unapprovedMentors = claim.mentors.filter(mentor =>
-      mentor.claim_assured === false || mentor.claim_assured === 'no'
+      mentor.claim_assured === false || mentor.claim_assured.toLowerCase() === 'no'
     )
 
     const hasUnapprovedMentor = unapprovedMentors.length > 0

--- a/app/controllers/support/sampling.js
+++ b/app/controllers/support/sampling.js
@@ -616,7 +616,7 @@ exports.review_response_claims_post = (req, res) => {
 
   claims.forEach(claim => {
     const unapprovedMentors = claim.mentors.filter(mentor =>
-      mentor.claim_assured === false || mentor.claim_assured.toLowerCase() === 'no'
+      mentor.claim_assured === false ||  ['false','no'].includes(mentor.claim_assured.toLowerCase())
     )
 
     const hasUnapprovedMentor = unapprovedMentors.length > 0

--- a/app/controllers/support/settings.js
+++ b/app/controllers/support/settings.js
@@ -210,6 +210,22 @@ exports.edit_claim_window_post = (req, res) => {
 
   const errors = []
 
+  if (req.session.data.window.opensAt === undefined) {
+    const error = {}
+    error.fieldName = 'date-window-opens'
+    error.href = '#date-window-opens'
+    error.text = 'Enter date the window opens'
+    errors.push(error)
+  }
+
+  if (req.session.data.window.closesAt === undefined) {
+    const error = {}
+    error.fieldName = 'date-window-closes'
+    error.href = '#date-window-closes'
+    error.text = 'Enter date the window closes'
+    errors.push(error)
+  }
+
   // if (!validationHelper.isValidDate(req.session.data.window.opensAt)) {
   //   const error = {}
   //   error.fieldName = 'date-window-opens'

--- a/app/helpers/sampling.js
+++ b/app/helpers/sampling.js
@@ -76,3 +76,48 @@ exports.parseProviderResponseData = (array) => {
 
   return claims
 }
+
+
+exports.groupClaimsByClaimId = (data) => {
+  const groupedClaims = data.reduce((acc, item) => {
+    const {
+      claimId,
+      claim_reference,
+      school_urn,
+      school_name,
+      school_postcode,
+      organisationId,
+      providerName,
+      providerNameSlug,
+      mentor_full_name,
+      mentor_hours_of_training,
+      claim_assured,
+      claim_not_assured_reason,
+    } = item;
+
+    if (!acc[claimId]) {
+      acc[claimId] = {
+        claimId,
+        claim_reference,
+        school_urn,
+        school_name,
+        school_postcode,
+        organisationId,
+        providerName,
+        providerNameSlug,
+        mentors: [],
+      };
+    }
+
+    acc[claimId].mentors.push({
+      mentor_full_name,
+      mentor_hours_of_training,
+      claim_assured,
+      claim_not_assured_reason,
+    });
+
+    return acc;
+  }, {});
+
+  return Object.values(groupedClaims);
+}

--- a/app/views/claims/declaration.njk
+++ b/app/views/claims/declaration.njk
@@ -47,6 +47,14 @@
             },
             {
               key: {
+                text: "Academic year"
+              },
+              value: {
+                text: claim.academicYear | getAcademicYearLabel
+              }
+            },
+            {
+              key: {
                 text: "Accredited provider"
               },
               value: {

--- a/app/views/support/claims/sampling/show.njk
+++ b/app/views/support/claims/sampling/show.njk
@@ -35,7 +35,7 @@
 
       {% if note and note.text.length %}
         {% set insetHtml %}
-          <h2 class="govuk-heading-s">Reason claim {{- " was not assured" if note.category == "sampling_payment_not_approved" else " is being sampled" }}</h2>
+          <h2 class="govuk-heading-s">Reason claim {{- " was not assured" if note.category == "sampling_provider_not_approved" else " is being sampled" }}</h2>
           <p class="govuk-body">{{ note.text }}</p>
         {% endset %}
         {{ govukInsetText({

--- a/app/views/support/settings/windows/delete.njk
+++ b/app/views/support/settings/windows/delete.njk
@@ -2,9 +2,9 @@
 
 {% set primaryNavId = "settings" %}
 
-{% set title = "Are you sure you want to remove this claim window?" %}
+{% set title = "Are you sure you want to remove " + window.opensAt | govukDate + " to " + window.closesAt | govukDate + " claim window?" %}
 
-{% set caption = "Claim window - " + window.opensAt | govukDate + " to " + window.closesAt | govukDate %}
+{% set caption = "Remove claim window" %}
 
 {% block pageTitle %}
   {{ "Error: " if errors.length }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
@@ -27,8 +27,6 @@
       {% include "_includes/page-heading.njk" %}
 
       <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
-
-
 
         {{ govukButton({
           text: "Remove claim window",


### PR DESCRIPTION
The provider response data is one mentor per line, which means there are multiple claim lines per claim in the data.

This fix:

- groups claims by ID
- checks if one mentor has not been assured to invalidate the whole claim
- groups all the not-assured reasons into one message to show